### PR TITLE
Release/1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ To change the System Locale, you also need to add the following permission to yo
     ...
 ```
 
+To change the App Locale via `LocaleTestRule`, you need to add the following dependency in your `app/build.gradle`
+```kotlin
+implementation 'androidx.appcompat:appcompat:1.6.0-rc01'
+```
+and 
+```kotlin
+compileSdkVersion 33
+```
+**Warning**: `LocaleTestRule` does not work together with `ActivityScenarioForActivityRule` or `ActivityScenarioConfigurator.ForActivity()`.
+
 ## Screenshot testing examples
 The examples use [pedrovgs/Shot](https://github.com/pedrovgs/Shot). It'd also work with any other on-device screenshot testing framework, like Facebook [screenshot-tests-for-android](https://github.com/facebook/screenshot-tests-for-android), Dropbox [Dropshots](https://github.com/dropbox/dropshots) or with a custom screenshot testing solution.
 

--- a/README.md
+++ b/README.md
@@ -3,57 +3,71 @@
 </a>
 
 # Android UI testing utils
+
 <p align="left">
 <img width="130" src="https://user-images.githubusercontent.com/6097181/172724660-778176b0-a6b0-4aad-b6b4-7115ad4fc7f3.png">
 </p>
 
-A set of *TestRules*, *ActivityScenarios* and utils to facilitate UI & screenshot testing under certain configurations, independent of the UI testing framework you are using.
+A set of *TestRules*, *ActivityScenarios* and utils to facilitate UI & screenshot testing under
+certain configurations, independent of the UI testing framework you are using.
 <br clear="left"/>
 </br></br>
-For screenshot testing, it supports **Jetpack Compose**, **android Views** (e.g. custom Views, ViewHolders, etc.), **Activities** and **Fragments**.
+For screenshot testing, it supports **Jetpack Compose**, **android Views** (e.g. custom Views,
+ViewHolders, etc.), **Activities** and **Fragments**.
 </br></br>
-Currently, with this library you can easily change the following configurations in your instrumented tests:
+Currently, with this library you can easily change the following configurations in your instrumented
+tests:
+
 1. Locale (also Pseudolocales **en_XA** & **ar_XB**)
-   1. App Locale (i.e. per-app language preference)
-   2. System Locale
+    1. App Locale (i.e. per-app language preference)
+    2. System Locale
 2. Font size
 3. Orientation
 4. Custom themes
 5. Dark mode /Day-Night mode
 6. Display size
 
-You can find out why verifying our design under such configurations is important in this blog post: 
+You can find out why verifying our design under such configurations is important in this blog post:
+
 - [Design a pixel perfect Android app 🎨](https://sergiosastre.hashnode.dev/design-a-pixel-perfect-android-app-with-screenshot-testing)
 
 In the near future, there are plans to also support, among others:
+
 1. Reduce snapshot testing flakiness
 2. Folding features
-3. Enable Accessibility features 
+3. Enable Accessibility features
 
 ## Sponsors
+
 Thanks to [Screenshotbot](https://screenshotbot.io) for their support!
 [<img align="left" width="100" src="https://user-images.githubusercontent.com/6097181/192350235-b3b5dc63-e7e7-48da-bdb6-851a130aaf8d.png">](https://screenshotbot.io)
 
-By using Screenshotbot instead of the in-build record/verify modes provided by most screenshot libraries, you'll give your colleages a better developer experience, since they will not be required to manually record screenshots after every run, instead getting notifications on their Pull Requests.
+By using Screenshotbot instead of the in-build record/verify modes provided by most screenshot
+libraries, you'll give your colleages a better developer experience, since they will not be required
+to manually record screenshots after every run, instead getting notifications on their Pull
+Requests.
 <br clear="left"/>
 
 ## Table of Contents
+
 - [Integration](#integration)
 - [Usage](#usage)
-    - [Configuration](#configuration)
-    - [Screnshot testing examples](#screenshot-testing-examples)
-        - [Activity](#activity)
-        - [Android View](#android-view)
-        - [Jetpack Compose](#jetpack-compose)
-        - [Fragment](#fragment)
-        - [Utils](#utils)
-        - [Reading on screenshot testing](#reading-on-screenshot-testing)
-    - [Standard UI testing](#standard-ui-testing)
+  - [Configuration](#configuration)
+  - [Screnshot testing examples](#screenshot-testing-examples)
+  - [Activity](#activity)
+  - [Android View](#android-view)
+  - [Jetpack Compose](#jetpack-compose)
+  - [Fragment](#fragment)
+  - [Utils](#utils)
+  - [Reading on screenshot testing](#reading-on-screenshot-testing)
+  - [Standard UI testing](#standard-ui-testing)
 - [Code attributions](#code-attributions)
 - [Contributing](#contributing)
 
 ## Integration
+
 Add jitpack to your root `build.gradle` file:
+
 ```groovy
 allprojects {
     repositories {
@@ -61,46 +75,53 @@ allprojects {
     }
 }
 ```
+
 Add a dependency to `build.gradle`
+
 ```groovy
 dependencies {
-    androidTestImplementation 'com.github.sergio-sastre:AndroidUiTestingUtils:1.2.0'
+    androidTestImplementation 'com.github.sergio-sastre:AndroidUiTestingUtils:1.2.1'
 }
 ```
+
+The latter will make the app crash with
+`java.lang.RuntimeException: This method can not be called from the main application thread`
 
 # Usage
+
 ## Configuration
+
 First, you need to add the following permission and activities to your `debug/manifest`
+
 ```xml
 <!-- Required for ActivityScenarios -->
-<application
-   ...
-   <activity android:name="sergio.sastre.uitesting.utils.activityscenario.ActivityScenarioConfigurator$PortraitSnapshotConfiguredActivity"/>
-   <activity android:name="sergio.sastre.uitesting.utils.activityscenario.ActivityScenarioConfigurator$LandscapeSnapshotConfiguredActivity"
-      android:screenOrientation="landscape"/>
-   ...
-</application>
+<application...<activity
+android:name="sergio.sastre.uitesting.utils.activityscenario.ActivityScenarioConfigurator$PortraitSnapshotConfiguredActivity" /><activity
+android:name="sergio.sastre.uitesting.utils.activityscenario.ActivityScenarioConfigurator$LandscapeSnapshotConfiguredActivity"
+android:screenOrientation="landscape" />...</application>
 ```
 
-To enable pseudolocales **en_XA** & **ar_XB** for your screenshot tests, add this to your build.gradle.
+To enable pseudolocales **en_XA** & **ar_XB** for your screenshot tests, add this to your
+build.gradle.
+
 ```groovy
 android {
-   ...
-   buildTypes {
-      ...
-      debug {
-         pseudoLocalesEnabled true
-      }
-   }
+    ...
+    buildTypes {
+        ...
+        debug {
+            pseudoLocalesEnabled true
+        }
+    }
 }
 ```
+
 To change the System Locale, you also need to add the following permission to your `debug/manifest`
+
 ```xml
 <!-- Required to change the Locale via SystemLocaleTestRule (required for snapshot testing Activities only) -->
-<uses-permission
-    android:name="android.permission.CHANGE_CONFIGURATION"
-    tools:ignore="ProtectedPermissions" />
-    ...
+<uses-permission android:name="android.permission.CHANGE_CONFIGURATION"
+    tools:ignore="ProtectedPermissions" />...
 ```
 
 To change the App Locale via `LocaleTestRule`, you need to add the following dependency in your `app/build.gradle`
@@ -114,13 +135,21 @@ compileSdkVersion 33
 **Warning**: `LocaleTestRule` does not work together with `ActivityScenarioForActivityRule` or `ActivityScenarioConfigurator.ForActivity()`.
 
 ## Screenshot testing examples
-The examples use [pedrovgs/Shot](https://github.com/pedrovgs/Shot). It'd also work with any other on-device screenshot testing framework, like Facebook [screenshot-tests-for-android](https://github.com/facebook/screenshot-tests-for-android), Dropbox [Dropshots](https://github.com/dropbox/dropshots) or with a custom screenshot testing solution.
+
+The examples use [pedrovgs/Shot](https://github.com/pedrovgs/Shot). It'd also work with any other
+on-device screenshot testing framework, like
+Facebook [screenshot-tests-for-android](https://github.com/facebook/screenshot-tests-for-android),
+Dropbox [Dropshots](https://github.com/dropbox/dropshots) or with a custom screenshot testing
+solution.
 
 ### Activity
-The simplest way is to use the **ActivityScenarioForActivityRule**, The simplest way is to use the **ActivityScenarioForViewRule**, to avoid the need for closing the ActivityScenario.
+
+The simplest way is to use the **ActivityScenarioForActivityRule**, The simplest way is to use
+the **ActivityScenarioForViewRule**, to avoid the need for closing the ActivityScenario.
+
 ```kotlin
 @get:Rule
-val rule = 
+val rule =
     activityScenarioForActivityRule<MyActivity>(
         config = ActivityConfigItem(
             orientation = Orientation.LANDSCAPE,
@@ -140,9 +169,11 @@ fun snapActivityTest() {
 }
 ```
 
-In case you don't want to/cannot use the rule, you can use **ActivityScenarioConfigurator.ForActivity()** directly in the test.
-Currently, this is the only means to set a timeOut for the FontSize and DisplaySize TestRules, if needed. 
-This would be its equivalent:
+In case you don't want to/cannot use the rule, you can use **
+ActivityScenarioConfigurator.ForActivity()** directly in the test. Currently, this is the only means
+to set a timeOut for the FontSize and DisplaySize TestRules, if needed. This would be its
+equivalent:
+
 ```kotlin
 // Sets the Locale of the Android system
 @get:Rule
@@ -153,7 +184,7 @@ val fontSize = FontSizeTestRule(FontSize.HUGE).withTimeOut(inMillis = 15_000) //
 
 @get:Rule
 val displaySize = DisplaySizeTestRule(DisplaySize.LARGEST).withTimeOut(inMillis = 15_000)
-   
+
 @Test
 fun snapActivityTest() {
     // Custom themes are not supported
@@ -162,19 +193,23 @@ fun snapActivityTest() {
         .setOrientation(Orientation.LANDSCAPE)
         .setUiMode(UiMode.NIGHT)
         .launch(MyActivity::class.java)
-        
+
     val activity = activityScenario.waitForActivity()
-    
+
     compareScreenshot(activity = activity, name = "your_unique_test_name")
-    
+
     activityScenario.close()
 }
 ```
+
 ### Android View
-The simplest way is to use the **ActivityScenarioForViewRule**, to avoid the need for closing the ActivityScenario.
+
+The simplest way is to use the **ActivityScenarioForViewRule**, to avoid the need for closing the
+ActivityScenario.
+
 ```kotlin
 @get:Rule
-val rule = 
+val rule =
     ActivityScenarioForViewRule(
         config = ViewConfigItem(
             fontSize = FontSize.NORMAL,
@@ -184,13 +219,13 @@ val rule =
             theme = R.style.Custom_Theme,
             displaySize = DisplaySize.SMALL,
         )
-    )    
+    )
 
 @Test
 fun snapViewHolderTest() {
     // IMPORTANT: The rule inflates a layout inside the activity with its context to inherit the configuration 
-    val layout = rule.inflate(R.layout.your_view_holder_layout)
-    
+    val layout = rule.inflateAndWaitForIdle(R.layout.your_view_holder_layout)
+
     // wait asynchronously for layout inflation 
     val viewHolder = waitForView {
         YourViewHolder(layout).apply {
@@ -207,8 +242,9 @@ fun snapViewHolderTest() {
 }
 ```
 
-In case you don't want to/cannot use the rule, you can use **ActivityScenarioConfigurator.ForView()**.
-This would be its equivalent:
+In case you don't want to/cannot use the rule, you can use **
+ActivityScenarioConfigurator.ForView()**. This would be its equivalent:
+
 ```kotlin
 // example for ViewHolder
 @Test
@@ -225,10 +261,8 @@ fun snapViewHolderTest() {
 
     val activity = activityScenario.waitForActivity()
 
-    val layout = waitForView {
-        // IMPORTANT: To inherit the configuration, inflate layout inside the activity with its context 
-        activity.inflate(R.layout.your_view_holder_layout)
-    }
+    // IMPORTANT: To inherit the configuration, inflate layout inside the activity with its context 
+    val layout = activity.inflateAndWaitForIdle(R.layout.your_view_holder_layout)
 
     // wait asynchronously for layout inflation 
     val viewHolder = waitForView {
@@ -237,24 +271,36 @@ fun snapViewHolderTest() {
             ...
         }
     }
-    
+
     compareScreenshot(
         holder = viewHolder,
         heightInPx = layout.height,
         name = "your_unique_test_name"
     )
-    
+
     activityScenario.close()
 }
 ```
-**Warning**: If the View under test contains system Locale dependent code, like `NumberFormat.getInstance(Locale.getDefault())`, the Locale formatting you've set via `ActivityScenarioConfigurator.ForView().setLocale("my_locale")` will not work. That's because NumberFormat is using the Locale of the Android system, and not that of the Activity we've configured. Beware of using `instrumenation.targetContext` in your tests when using getString() for the very same reason: use Activity's context instead. </br> To solve that issue, you can do one of the following:
+
+**Warning**: If the View under test contains system Locale dependent code,
+like `NumberFormat.getInstance(Locale.getDefault())`, the Locale formatting you've set
+via `ActivityScenarioConfigurator.ForView().setLocale("my_locale")` will not work. That's because
+NumberFormat is using the Locale of the Android system, and not that of the Activity we've
+configured. Beware of using `instrumenation.targetContext` in your tests when using getString() for
+the very same reason: use Activity's context instead. </br> To solve that issue, you can do one of
+the following:
+
 1. Use `NumberFormat.getInstance(anyViewInsideActivity.context.locales[0])` in your production code.
-2. Use `SystemLocaleTestRule("my_locale")` in your tests instead of `ActivityScenarioConfigurator.ForView().setLocale("my_locale")`.
+2. Use `SystemLocaleTestRule("my_locale")` in your tests instead
+   of `ActivityScenarioConfigurator.ForView().setLocale("my_locale")`.
 
 ### Jetpack Compose
+
 The simplest way is to use the **ActivityScenarioForComposableRule**, to avoid the need for:
+
 1) calling createEmptyComposeRule()
 2) closing the ActivityScenario.
+
 ```kotlin
 @get:Rule
 val rule = ActivityScenarioForComposableRule(
@@ -279,13 +325,16 @@ fun snapComposableTest() {
         }
 
     compareScreenshot(
-        rule = rule.composeTestRule, 
+        rule = rule.composeRule,
         name = "your_unique_test_name"
     )
 }
 ```
-In case you don't want to/cannot use the rule, you can use **ActivityScenarioConfigurator.ForComposable()** together with **createEmptyComposeRule()**.
-This would be its equivalent:
+
+In case you don't want to/cannot use the rule, you can use **
+ActivityScenarioConfigurator.ForComposable()** together with **createEmptyComposeRule()**. This
+would be its equivalent:
+
 ```kotlin
 // needs an EmptyComposeRule to be compatible with ActivityScenario
 @get:Rule
@@ -307,45 +356,56 @@ fun snapComposableTest() {
                 }
             }
         }
-        
+
     activityScenario.waitForActivity()
 
     compareScreenshot(rule = composeTestRule, name = "your_unique_test_name")
-    
+
     activityScenario.close()
 }
 ```
-**Warning**: If the Composable under test contains system Locale dependent code, like `NumberFormat.getInstance(Locale.getDefault())`, the Locale formatting you've set via `ActivityScenarioConfigurator.ForComposable().setLocale("my_locale")` will not work. That's because NumberFormat is using the Locale of the Android system, and not that of the Activity we've configured, which is applied to the LocaleContext of our Composables. </br> To solve that issue, you can do one of the following:
+
+**Warning**: If the Composable under test contains system Locale dependent code,
+like `NumberFormat.getInstance(Locale.getDefault())`, the Locale formatting you've set
+via `ActivityScenarioConfigurator.ForComposable().setLocale("my_locale")` will not work. That's
+because NumberFormat is using the Locale of the Android system, and not that of the Activity we've
+configured, which is applied to the LocaleContext of our Composables. </br> To solve that issue, you
+can do one of the following:
+
 1. Use `NumberFormat.getInstance(LocaleContext.current.locales[0])` in your production code.
-2. Use `SystemLocaleTestRule("my_locale")` in your tests instead of `ActivityScenarioConfigurator.ForComposable().setLocale("my_locale")`.
+2. Use `SystemLocaleTestRule("my_locale")` in your tests instead
+   of `ActivityScenarioConfigurator.ForComposable().setLocale("my_locale")`.
 
 ### Fragment
+
 The simplest way is to use the **FragmentScenarioConfiguratorRule**
+
 ```kotlin
 @get:Rule
-val fragmentScenarioRule = fragmentScenarioConfiguratorRule<MyFragment>(
-    fragmentArgs = bundleOf("arg_key" to "arg_value"),
-    configItemWithTheme = FragmentConfigItem(
-        orientation = Orientation.LANDSCAPE,
-        uiMode = UiMode.DAY,
-        locale = "de",
-        fontSize = FontSize.SMALL,
-        displaySize = DisplaySize.SMALL,
-        theme = R.style.Custom_Theme,
-    ),
-)
+val rule = fragmentScenarioConfiguratorRule<MyFragment>(
+        fragmentArgs = bundleOf("arg_key" to "arg_value"),
+        config = FragmentConfigItem(
+            orientation = Orientation.LANDSCAPE,
+            uiMode = UiMode.DAY,
+            locale = "de",
+            fontSize = FontSize.SMALL,
+            displaySize = DisplaySize.SMALL,
+            theme = R.style.Custom_Theme,
+        ),
+    )
 
 @Test
 fun snapFragment() {
     compareScreenshot(
-        fragment = fragmentScenarioRule.fragmentScenario.waitForFragment(),
+        fragment = rule.fragment,
         name = "your_unique_test_name",
     )
 }
 ```
 
-In case you don't want to/cannot use the rule, you can use the plain **FragmentScenarioConfigurator**.
-This would be its equivalent:
+In case you don't want to/cannot use the rule, you can use the plain **
+FragmentScenarioConfigurator**. This would be its equivalent:
+
 ```kotlin
 @Test
 fun snapFragment() {
@@ -369,25 +429,43 @@ fun snapFragment() {
     fragmentScenarioConfigurator.close()
 }
 ```
+
 ### Utils
+
 1. waitForActivity:
-   This method is analog to the one defined in [pedrovgs/Shot](https://github.com/pedrovgs/Shot). It's also available in this library for compatibility with other screenshot testing frameworks like Facebook [screenshot-tests-for-android](https://github.com/facebook/screenshot-tests-for-android).
+   This method is analog to the one defined in [pedrovgs/Shot](https://github.com/pedrovgs/Shot).
+   It's also available in this library for compatibility with other screenshot testing frameworks
+   like
+   Facebook [screenshot-tests-for-android](https://github.com/facebook/screenshot-tests-for-android)
+   .
 
 2. waitForFragment: Analog to waitForActivity but for Fragment
 
-3. waitForView: Inflates the layout in the main thread and waits till the inflation happens, returning the inflated view. You will need to inflate layouts with the activity context created from the ActivityScenario of this library for the configurations to become effective.
+3. waitForView: Inflates the layout in the main thread and waits till the inflation happens,
+   returning the inflated view. You will need to inflate layouts with the activity context created
+   from the ActivityScenario of this library for the configurations to become effective.
 
-4. activity.inflate(R.layout_of_your_view): Use it to inflate android Views with the activity's context configuration.
-In doing so, the configuration becomes effective in the view. It also adds the view to the Activity's root.
+4. activity.inflate(R.layout_of_your_view): Use it to inflate android Views with the activity's
+   context configuration. In doing so, the configuration becomes effective in the view. It also adds
+   the view to the Activity's root.
+
+5. activity.inflateAndWaitForIdle(R.layout_of_your_view): Like activity.inflate, but waits till the view is Idle to return it.
+   Do not wrap it with waitForView{} or it will throw an exception.
+
 
 ### Reading on screenshot testing
+
 - [An introduction to snapshot testing on Android in 2021 📸](https://sergiosastre.hashnode.dev/an-introduction-to-snapshot-testing-on-android-in-2021)
 - [The secrets of effectively snapshot testing on Android 🔓](https://sergiosastre.hashnode.dev/the-secrets-of-effectively-snapshot-testing-on-android)
 - [UI tests vs. snapshot tests on Android: which one should I write? 🤔](https://sergiosastre.hashnode.dev/ui-tests-vs-snapshot-tests-on-android-which-one-should-i-write)
 - [Design a pixel perfect Android app 🎨](https://sergiosastre.hashnode.dev/design-a-pixel-perfect-android-app-with-screenshot-testing)
 
 ## Standard UI testing
-For standard UI testing, you can use the same approach as for snapshot testing Activities. In case you do not want to use ActivityScenario at all in your tests, the following TestRules and methods are provided:
+
+For standard UI testing, you can use the same approach as for snapshot testing Activities. In case
+you do not want to use ActivityScenario at all in your tests, the following TestRules and methods
+are provided:
+
 ```kotlin
 // Sets the Locale of the app under test only, i.e. the per-app language preference feature
 @get:Rule
@@ -408,29 +486,47 @@ val uiMode = DayNightRule(UiMode.NIGHT)
 
 activity.rotateTo(Orientation.LANDSCAPE)
 ```
-**WARNING**: When using *DisplaySizeTestRule* and *FontSizeTesRule* together in the same test, make sure your emulator has enough RAM and VM heap to avoid Exceptions when running the tests.
-The recommended configuration is the following:
+
+**WARNING**: When using *DisplaySizeTestRule* and *FontSizeTesRule* together in the same test, make
+sure your emulator has enough RAM and VM heap to avoid Exceptions when running the tests. The
+recommended configuration is the following:
+
 - RAM: 4GB
 - VM heap: 1GB
 
 # Code attributions
-This library has been possible due to the work others have done previously. Most TestRules are based on code written by others:
-- SystemLocaleTestRule -> [Screengrab](https://github.com/fastlane/fastlane/tree/master/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale)
-- FontSizeTestRule -> [Novoda/espresso-support](https://github.com/novoda/espresso-support/tree/master/core/src/main/java/com/novoda/espresso)
+
+This library has been possible due to the work others have done previously. Most TestRules are based
+on code written by others:
+
+- SystemLocaleTestRule
+  -> [Screengrab](https://github.com/fastlane/fastlane/tree/master/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale)
+- FontSizeTestRule
+  -> [Novoda/espresso-support](https://github.com/novoda/espresso-support/tree/master/core/src/main/java/com/novoda/espresso)
 - UiModeTestRule -> [AdevintaSpain/Barista](https://github.com/AdevintaSpain/Barista)
-- Orientation change for activities -> [Shopify/android-testify](https://github.com/Shopify/android-testify/)
+- Orientation change for activities
+  -> [Shopify/android-testify](https://github.com/Shopify/android-testify/)
 
 # Contributing
+
 1. Create an issue in this repo
-2. Fork the repo [Road to effective snapshot testing](https://github.com/sergio-sastre/RoadToEffectiveSnapshotTesting)
-3. In that repo, add an example and test where the bug is reproducible/ and showcasing the new feature.
-4. Once pushed, add a link to the PR in the issue created in this repo and add @sergio-sastre as a reviewer.
+2. Fork the
+   repo [Road to effective snapshot testing](https://github.com/sergio-sastre/RoadToEffectiveSnapshotTesting)
+3. In that repo, add an example and test where the bug is reproducible/ and showcasing the new
+   feature.
+4. Once pushed, add a link to the PR in the issue created in this repo and add @sergio-sastre as a
+   reviewer.
 5. Once reviewed and approved, create an issue in this repo.
-6. Fork this repo and add the approved code from the other repo to this one (no example or test needed). Add @sergio-sastre as a reviewer.
-7. Once approved, I will merge the code in both repos, and you will be added as a contributor to [Android UI testing utils](https://github.com/sergio-sastre/AndroidUiTestingUtils) as well as [Road to effective snapshot testing](https://github.com/sergio-sastre/RoadToEffectiveSnapshotTesting). 
+6. Fork this repo and add the approved code from the other repo to this one (no example or test
+   needed). Add @sergio-sastre as a reviewer.
+7. Once approved, I will merge the code in both repos, and you will be added as a contributor
+   to [Android UI testing utils](https://github.com/sergio-sastre/AndroidUiTestingUtils) as well
+   as [Road to effective snapshot testing](https://github.com/sergio-sastre/RoadToEffectiveSnapshotTesting)
+   .
 
 I'll try to make the process easier in the future if I see many issues/feature requests incoming :)
 
 </br></br>
-<a href="https://www.flaticon.com/free-icons/ninja" title="ninja icons">Android UI testing utils logo modified from one by Freepik - Flaticon</a>
+<a href="https://www.flaticon.com/free-icons/ninja" title="ninja icons">Android UI testing utils
+logo modified from one by Freepik - Flaticon</a>
 

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -11,8 +11,8 @@ android {
         minSdk 21
         targetSdk 33
 
-        versionCode 8
-        versionName "1.2.0"
+        versionCode 9
+        versionName "1.2.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -53,7 +53,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'sergio.sastre'
                 artifactId = 'uitesting.utils'
-                version = '1.2.0'
+                version = '1.2.1'
             }
         }
     }

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/activityscenario/ActivityScenarioForViewRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/activityscenario/ActivityScenarioForViewRule.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import androidx.annotation.LayoutRes
 import org.junit.rules.ExternalResource
 import sergio.sastre.uitesting.utils.utils.inflate
+import sergio.sastre.uitesting.utils.utils.inflateAndWaitForIdle
 import sergio.sastre.uitesting.utils.utils.waitForActivity
 
 class ActivityScenarioForViewRule(
@@ -22,8 +23,8 @@ class ActivityScenarioForViewRule(
 
     val activity: Activity by lazy { activityScenario.waitForActivity() }
 
-    fun inflate(@LayoutRes layoutId: Int, id: Int = android.R.id.content) =
-        activity.inflate(layoutId, id)
+    fun inflateAndWaitForIdle(@LayoutRes layoutId: Int, id: Int = android.R.id.content) =
+        activity.inflateAndWaitForIdle(layoutId, id)
 
     override fun after() {
         activityScenario.close()

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/fragmentscenario/FragmentScenarioConfiguratorExt.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/fragmentscenario/FragmentScenarioConfiguratorExt.kt
@@ -32,11 +32,11 @@ inline fun <reified T : Fragment> fragmentScenarioConfiguratorRule(
     fragmentArgs: Bundle? = null,
     initialState: Lifecycle.State = Lifecycle.State.RESUMED,
     factory: FragmentFactory? = null,
-    configItemWithTheme: FragmentConfigItem? = null,
+    config: FragmentConfigItem? = null,
 ): FragmentScenarioConfiguratorRule<T> = FragmentScenarioConfiguratorRule(
     T::class.java,
     fragmentArgs,
     initialState,
     factory,
-    configItemWithTheme,
+    config,
 )

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/fragmentscenario/FragmentScenarioConfiguratorRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/fragmentscenario/FragmentScenarioConfiguratorRule.kt
@@ -24,6 +24,10 @@ class FragmentScenarioConfiguratorRule<F : Fragment>(
                 config?.theme?.also { theme -> setTheme(theme) }
             }.launchInContainer(fragmentClass, fragmentArgs, initialState, factory)
 
+    val fragment: Fragment by lazy {
+        fragmentScenario.waitForFragment()
+    }
+
     override fun after() {
         fragmentScenario.close()
     }

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/locale/LocaleTestRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/locale/LocaleTestRule.kt
@@ -14,6 +14,10 @@ import kotlin.Throws
 
 /**
  * A TestRule to change the Locale of the application.
+ *
+ * Warning: it currently does not work together with
+ * 1. ActivityScenarioForActivityRule
+ * 2. ActivityScenarioConfigurator.ForActivity()
  */
 class LocaleTestRule : TestRule {
     private val testLocale: Locale?

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/utils/Extensions.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/utils/Extensions.kt
@@ -25,6 +25,21 @@ import sergio.sastre.uitesting.utils.common.Orientation
  */
 fun Activity.inflate(@LayoutRes layoutId: Int, id: Int = android.R.id.content): View {
     val root = findViewById<View>(id) as ViewGroup
+    return LayoutInflater.from(this).inflate(layoutId, root, true)
+}
+
+/**
+ * Returns a view with [layoutId] using the context of [Activity], and attaches it to the root.
+ * In addition to [inflate], it also waits synchronously till the main thread is Idle.
+ *
+ * This is meant to snapshot test custom views, ViewHolders, Dialogs, etc. after launching an
+ * Activity via ActivityScenarioConfigurator.
+ *
+ * All views inflated with the context of this Activity inherit its configuration, like Locale,
+ * FontSize, UiMode, etc.
+ */
+fun Activity.inflateAndWaitForIdle(@LayoutRes layoutId: Int, id: Int = android.R.id.content): View {
+    val root = findViewById<View>(id) as ViewGroup
     return waitForView {
         LayoutInflater.from(this).inflate(layoutId, root, true)
     }


### PR DESCRIPTION
Add support for:
- **Locale** in 2 different forms:
   1. **App Locale** (i.e. per-app language preference)
   2. **System Locale**
- **Fragments** via FragmentScenarioConfigurator 
- **Custom themes** for Views and Fragments via setTheme()
- **ActivityScenarioConfigurator & FragmentScenarioConfigurator rules** for less verbose tests