### PR TITLE
Update dependencies

### DIFF
--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -35,8 +35,9 @@ android {
 }
 
 dependencies {
-    api 'androidx.appcompat:appcompat:1.6.0-rc01'
-    api 'com.google.android.material:material:1.6.1'
+    api 'androidx.appcompat:appcompat:1.7.0-alpha01'
+    api 'com.google.android.material:material:1.7.0'
+    api 'androidx.test:core:1.5.0-beta01'
     api 'androidx.core:core-ktx:1.9.0'
     api 'androidx.test.ext:junit:1.1.3'
     api 'androidx.test.espresso:espresso-core:3.4.0'


### PR DESCRIPTION
1. Adding the api 'androidx.test:core:1.5.0-beta01' dependency fixes the crash on api 33

2. Update other dependencies