### PR TITLE
set font size always via adb

### DIFF
--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/fontsize/FontScaleSetting.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/fontsize/FontScaleSetting.kt
@@ -3,8 +3,6 @@ package sergio.sastre.uitesting.utils.testrules.fontsize
 /**
  * Concept taken from : https://github.com/novoda/espresso-support
  */
-import android.content.res.Resources
-import android.os.Build
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import sergio.sastre.uitesting.utils.common.FontSize
 import sergio.sastre.uitesting.utils.utils.waitForExecuteShellCommand
@@ -20,25 +18,13 @@ class FontScaleSetting internal constructor() {
 
     fun set(scale: FontSize) {
         try {
-            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N) {
-                changeFontScaleFromApi25(scale)
-            } else {
-                changeFontScalePreApi25(scale)
-            }
+            changeFontScale(scale)
         } catch (e: Exception) {
             throw saveFontScaleError(scale)
         }
     }
 
-    @Suppress("DEPRECATION")
-    private fun changeFontScalePreApi25(scale: FontSize) {
-        resources.configuration.fontScale = java.lang.Float.parseFloat(scale.value)
-        val metrics = Resources.getSystem().displayMetrics
-        metrics.scaledDensity = resources.configuration.fontScale * metrics.density
-        resources.updateConfiguration(resources.configuration, metrics)
-    }
-
-    private fun changeFontScaleFromApi25(scale: FontSize) {
+    private fun changeFontScale(scale: FontSize) {
         getInstrumentation().waitForExecuteShellCommand("settings put system font_scale " + scale.value)
     }
 

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/fontsize/FontSizeTestRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/fontsize/FontSizeTestRule.kt
@@ -16,9 +16,7 @@ import sergio.sastre.uitesting.utils.testrules.fontsize.FontSizeTestRule.FontSca
 import sergio.sastre.uitesting.utils.testrules.fontsize.FontSizeTestRule.FontScaleStatement.Companion.SLEEP_TO_WAIT_FOR_SETTING_MILLIS
 
 /**
- * A TestRule to change FontSize of the device/emulator. It is done:
- * - API < 25 : modifying resources.configuration
- * - API 25 + : via adb (slower)
+ * A TestRule to change FontSize of the device/emulator. It is done via adb
  *
  * Strongly based on code from espresso-support library, from Novoda
  * https://github.com/novoda/espresso-support/tree/master/core/src/main/java/com/novoda/espresso


### PR DESCRIPTION
This makes FontSizeTestRule 100% compatible with android-testify screenshot testing library