### PR TITLE
Fix InAppLocaleTestRule not working reliably on API 31

### DIFF
--- a/inapplocale/src/main/java/sergio/sastre/uitesting/inapplocale/OnActivityCreatedCallback.kt
+++ b/inapplocale/src/main/java/sergio/sastre/uitesting/inapplocale/OnActivityCreatedCallback.kt
@@ -1,0 +1,35 @@
+package sergio.sastre.uitesting.inapplocale
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+
+internal interface OnActivityCreatedCallback: Application.ActivityLifecycleCallbacks {
+
+    override fun onActivityStarted(activity: Activity) {
+        // no-op
+    }
+
+    override fun onActivityResumed(activity: Activity) {
+        // no-op
+    }
+
+    override fun onActivityPaused(activity: Activity) {
+        // no-op
+    }
+
+    override fun onActivityStopped(activity: Activity) {
+        // no-op
+    }
+
+    override fun onActivitySaveInstanceState(
+        activity: Activity,
+        outState: Bundle
+    ) {
+        // no-op
+    }
+
+    override fun onActivityDestroyed(activity: Activity) {
+        // no-op
+    }
+}

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -37,7 +37,7 @@ android {
 }
 
 dependencies {
-    api 'androidx.appcompat:appcompat:1.7.0-alpha01'
+    api 'androidx.appcompat:appcompat:1.7.0-alpha02'
     api 'com.google.android.material:material:1.8.0'
     api 'androidx.test:core:1.5.0'
     api 'androidx.core:core-ktx:1.9.0'


### PR DESCRIPTION
`AppCompatDelegate.setApplicationLocales(locale)` works differently from API 33.
Therefore,  the changes might work on API 33, but not on previous ones.
This PR fixes that, which was overseen in the PR that was supposed to fix the problem