### PR TITLE
set FontSize via adb from API 24+

### DIFF
--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/fontsize/FontScaleSetting.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/fontsize/FontScaleSetting.kt
@@ -20,22 +20,22 @@ class FontScaleSetting internal constructor() {
 
     fun set(scale: FontSize) {
         try {
-            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N) {
-                changeFontScaleFromApi25(scale)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                changeFontScaleFromApi24(scale)
             } else {
-                changeFontScalePreApi25(scale)
+                changeFontScalePreApi24(scale)
             }
         } catch (e: Exception) {
             throw saveFontScaleError(scale)
         }
     }
 
-    private fun changeFontScaleFromApi25(scale: FontSize) {
+    private fun changeFontScaleFromApi24(scale: FontSize) {
         getInstrumentation().waitForExecuteShellCommand("settings put system font_scale " + scale.value)
     }
 
     @Suppress("DEPRECATION")
-    private fun changeFontScalePreApi25(scale: FontSize) {
+    private fun changeFontScalePreApi24(scale: FontSize) {
         resources.configuration.fontScale = java.lang.Float.parseFloat(scale.value)
         val metrics = Resources.getSystem().displayMetrics
         metrics.scaledDensity = resources.configuration.fontScale * metrics.density

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/fontsize/FontSizeTestRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/fontsize/FontSizeTestRule.kt
@@ -17,7 +17,7 @@ import sergio.sastre.uitesting.utils.testrules.fontsize.FontSizeTestRule.FontSca
 import sergio.sastre.uitesting.utils.testrules.fontsize.FontSizeTestRule.FontScaleStatement.Companion.SLEEP_TO_WAIT_FOR_SETTING_MILLIS
 
 /**
- * A TestRule to change FontSize of the device/emulator. It is done via adb
+ * A TestRule to change FontSize of the device/emulator. It is done via adb from API 24+
  *
  * Strongly based on code from espresso-support library, from Novoda
  * https://github.com/novoda/espresso-support/tree/master/core/src/main/java/com/novoda/espresso


### PR DESCRIPTION
Required since doing it via update configuration works only if the device is not rotated (e.g. Orientation.LANDSCAPE)

Apparently, there is no solution on API 23, since it does not take effect without rebooting the device