### PR TITLE
Release/2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ allprojects {
 
 ```groovy
 dependencies {
-    androidTestImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.0.0') {
+    androidTestImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.0.1') {
         // if necessary, add this to avoid compose version clashes
         exclude group: 'androidx.compose.ui'
     }
@@ -162,8 +162,8 @@ Configure your robolectric screenshot tests similar to how you'd do it with on-d
 For that, add the following dependencies in your `build.gradle`:
 
 ```kotlin
-testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.0.0'
-testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.0.0'
+testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.0.1'
+testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.0.1'
 ```
 
 If you get any error due to "Activity not found" in your application module, add the following to your `debug/manifest`
@@ -198,31 +198,37 @@ This section covers the basics: how to configure cross-library screenshot test t
 It's possible to configure several libraries though<sup>1</sup>. For shared screenshot tests (i.e. on-device + JVM), check [the next section](#shared-tests)</br></br>
 
 1. First of all, configure all the screenshot testing libraries you want your tests to support, as
-   if you'd write them with those specific libraries. Visit their respective Github pages for more info.
+   if you'd write them with those specific libraries. Visit their respective Github pages for more info.</br></br>
+   Use the AndroidUiTestingUtils version corresponding to the screenshot library version you're using:</br>
+
+   | AndroidUiTestingUtils | Roborazzi      | Paparazzi | Dropshots | Shot   |
+      | --------------------- | -------------- | --------- | --------- | ------ |
+   | *2.0.1*               | *1.7.0-rc-1*   |  1.3.1    | 0.4.1     | 6.0.0  |
+   | 2.0.0                 | 1.5.0-rc-1     |  1.3.1    | 0.4.1     | 6.0.0  |
 
 2. After that, include the following dependencies in the `build.gradle` of the module that will include your cross-library screenshot
    tests.
 
 ```
 dependencies {
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.0.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:<version>')
 
     // NOTE: From here down, add only those for the libraries you're planning to use
 
     // For Shot support
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.0.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:<version>')
 
     // For Dropshots support
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.0.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:<version>')
 
     // For Paparazzi support, AGP 8.0.0+ required
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-paparazzi:2.0.0')
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.0.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-paparazzi:<version>')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:<version>')
 
     // For Roborazzi support
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.0.0')
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.0.0')
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.0.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:<version>')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:<version>')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:<version>')
 }
 ```
  If using Roborazzi, enable robolectric native graphics through gradle as well
@@ -264,12 +270,6 @@ Want to try it out? Check out these executable examples:
 - [Cross-library screenshot test example](https://github.com/sergio-sastre/Android-screenshot-testing-playground/blob/master/lazycolumnscreen/crosslibrary/src/sharedTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/crosslibrary/CoffeeDrinkAppBarComposableTest.kt)
 - [Parameterized Cross-library screenshot test example](https://github.com/sergio-sastre/Android-screenshot-testing-playground/blob/master/lazycolumnscreen/crosslibrary/src/sharedTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/crosslibrary/parameterized/CoffeeDrinkListComposableParameterizedTest.kt)
 
-<sup>1</sup> It's very likely you'll configure your screenshot tests to run with maximum 1 on-device (i.e. either Shot or Dropshots) and/or 1 JVM library (i.e. Paparazzi). In that case, this or the [shared tests section](#shared-tests) are enough.</br>
-But if you wish to configure many on-device or many JVM libraries at the same time, and dynamically pick the one your screenshot tests run with, you'll need some extra configuration. For that you can use a custom gradle property passed via command line e.g. `-PscreenshotLibrary=shot`. Check these links for advice on how to configure the gradle file and the `SharedScreenshotTestRule` to get it working:</br>
-- [build.gradle](https://github.com/sergio-sastre/Android-screenshot-testing-playground/blob/master/lazycolumnscreen/crosslibrary/build.gradle)
-- [CrossLibraryScreenshotTestRule.kt](https://github.com/sergio-sastre/Android-screenshot-testing-playground/blob/master/lazycolumnscreen/crosslibrary/src/sharedTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/crosslibrary/utils/CrossLibraryScreenshotTestRule.kt)
-
-
 #### Shared tests
 If instead of using just one screenshot testing library at once, you want to enable shared tests (i.e same test running either on the JVM or on a device/emulator),you have to share resources between unitTests and AndroidTests.</br>
 The easiest way is to add this in the `build.gradle` of the module where you'll write shared tests and then write your screenshot tests under `src/sharedTest`,
@@ -310,7 +310,12 @@ class CrossLibraryScreenshotTestRule(
 ```
 
 4. Finally, write your tests with the `CrossLibraryScreenshotTestRule`. For an example, see [this section](#cross-library).</br></br>
-   Depending on the approach you chose to share tests, you must put them either in the `shared test module` we've created for that purpose (option 1), or under the `sharedTest` folder we've just defined (option 2). 
+   Depending on the approach you chose to share tests, you must put them either in the `shared test module` we've created for that purpose (option 1), or under the `sharedTest` folder we've just defined (option 2).
+
+<sup>1</sup> It's very likely you'll configure your screenshot tests to run with maximum 1 on-device (i.e. either Shot or Dropshots) and/or 1 JVM library (i.e. Paparazzi). In that case, this is enough.</br>
+But if you wish to configure many on-device or many JVM libraries at the same time, and dynamically pick the one your screenshot tests run with, you'll need some extra configuration. For that you can use a custom gradle property passed via command line e.g. `-PscreenshotLibrary=shot`. Check these links for advice on how to configure the gradle file and the `SharedScreenshotTestRule` to get it working:</br>
+- [build.gradle](https://github.com/sergio-sastre/Android-screenshot-testing-playground/blob/master/lazycolumnscreen/crosslibrary/build.gradle)
+- [CrossLibraryScreenshotTestRule.kt](https://github.com/sergio-sastre/Android-screenshot-testing-playground/blob/master/lazycolumnscreen/crosslibrary/src/sharedTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/crosslibrary/utils/CrossLibraryScreenshotTestRule.kt)
 
 # Usage
 
@@ -395,16 +400,6 @@ fun snapActivityTest() {
     activityScenario.close()
 }
 ```
-
-> **Warning**</br>
-> If using any TestRule with Ndtp [android-testify](https://github.com/ndtp/android-testify),
-> use `launchActivity = false` for them to take effect:
-> ```kotlin
-> @get:Rule
-> val activityTestRule =
->     ScreenshotRule(CoffeeDrinksComposeActivity::class.java, launchActivity = false)
->```
->
 
 ### Android View
 

--- a/dropshots/build.gradle
+++ b/dropshots/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdk 23
         targetSdk 33
-        versionCode 21
-        versionName "2.0.0"
+        versionCode 22
+        versionName "2.0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -54,7 +54,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "dropshots"
-            version = '2.0.0'
+            version = '2.0.1'
 
             afterEvaluate {
                 from components.release

--- a/mapper-paparazzi/build.gradle
+++ b/mapper-paparazzi/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdk 23
         targetSdk 33
-        versionCode 21
-        versionName "2.0.0"
+        versionCode 22
+        versionName "2.0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -42,7 +42,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "mapper-paparazzi"
-            version = '2.0.0'
+            version = '2.0.1'
 
             afterEvaluate {
                 from components.release

--- a/mapper-roborazzi/build.gradle
+++ b/mapper-roborazzi/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdk 23
         targetSdk 33
-        versionCode 21
-        versionName "2.0.0"
+        versionCode 22
+        versionName "2.0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -43,7 +43,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "mapper-roborazzi"
-            version = '2.0.0'
+            version = '2.0.1'
 
             afterEvaluate {
                 from components.release

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdk 23
         targetSdk 33
-        versionCode 21
-        versionName "2.0.0"
+        versionCode 22
+        versionName "2.0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -52,7 +52,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "paparazzi"
-            version = '2.0.0'
+            version = '2.0.1'
 
             afterEvaluate {
                 from components.release

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdk 23
         targetSdk 33
-        versionCode 21
-        versionName "2.0.0"
+        versionCode 22
+        versionName "2.0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -34,7 +34,7 @@ android {
 
 dependencies {
     implementation project(':utils')
-    implementation "org.robolectric:robolectric:4.10.3"
+    implementation "org.robolectric:robolectric:4.11-beta-2"
 }
 
 //https://www.talentica.com/blogs/publish-your-android-library-on-jitpack-for-better-reachability/
@@ -43,7 +43,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "robolectric"
-            version = '2.0.0'
+            version = '2.0.1'
 
             afterEvaluate {
                 from components.release

--- a/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/config/screen/DeviceScreen.kt
+++ b/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/config/screen/DeviceScreen.kt
@@ -13,6 +13,7 @@ data class DeviceScreen(
     val defaultOrientation: ScreenOrientation = ScreenOrientation.PORTRAIT,
     val round: RoundScreen? = null,
     val type: ScreenType? = null,
+    val name: String = ""
 ) {
 
     object Phone {
@@ -23,6 +24,7 @@ data class DeviceScreen(
             size = ScreenSize.NORMAL,
             aspect = ScreenAspect.LONG,
             density = ScreenDensity.HDPI,
+            name = "NEXUS_ONE"
         )
 
         @JvmField
@@ -32,6 +34,7 @@ data class DeviceScreen(
             size = ScreenSize.NORMAL,
             aspect = ScreenAspect.NOTLONG,
             density = ScreenDensity.XHDPI,
+            name = "NEXUS_4"
         )
 
         @JvmField
@@ -41,6 +44,7 @@ data class DeviceScreen(
             size = ScreenSize.LARGE,
             aspect = ScreenAspect.NOTLONG,
             density = ScreenDensity.XHDPI,
+            name = "NEXUS_7"
         )
 
         @JvmField
@@ -50,6 +54,7 @@ data class DeviceScreen(
             size = ScreenSize.XLARGE,
             aspect = ScreenAspect.NOTLONG,
             density = ScreenDensity.XHDPI,
+            name = "NEXUS_9"
         )
 
         @JvmField
@@ -59,6 +64,7 @@ data class DeviceScreen(
             size = ScreenSize.XLARGE,
             aspect = ScreenAspect.NOTLONG,
             density = ScreenDensity.XHDPI,
+            name = "PIXEL_C"
         )
 
         @JvmField
@@ -68,6 +74,7 @@ data class DeviceScreen(
             size = ScreenSize.NORMAL,
             aspect = ScreenAspect.NOTLONG,
             density = ScreenDensity.DPI_560,
+            name = "PIXEL_XL"
         )
 
         @JvmField
@@ -77,6 +84,7 @@ data class DeviceScreen(
             size = ScreenSize.NORMAL,
             aspect = ScreenAspect.LONG,
             density = ScreenDensity.DPI_440,
+            name = "PIXEL_4"
         )
 
         @JvmField
@@ -86,6 +94,7 @@ data class DeviceScreen(
             size = ScreenSize.NORMAL,
             aspect = ScreenAspect.LONG,
             density = ScreenDensity.DPI_560,
+            name = "PIXEL_4_XL"
         )
 
         @JvmField
@@ -95,6 +104,7 @@ data class DeviceScreen(
             size = ScreenSize.NORMAL,
             aspect = ScreenAspect.LONG,
             density = ScreenDensity.DPI_440,
+            name = "PIXEL_4A"
         )
 
         @JvmField
@@ -104,6 +114,71 @@ data class DeviceScreen(
             size = ScreenSize.XLARGE,
             aspect = ScreenAspect.LONG,
             density = ScreenDensity.DPI_440,
+            name = "PIXEL_5"
+        )
+
+        @JvmField
+        val SMALL_PHONE = DeviceScreen(
+            widthDp = 360,
+            heightDp = 640,
+            size = ScreenSize.NORMAL,
+            aspect = ScreenAspect.LONG,
+            density = ScreenDensity.XHDPI,
+            name = "SMALL_PHONE"
+        )
+
+        @JvmField
+        val MEDIUM_PHONE = DeviceScreen(
+            widthDp = 411,
+            heightDp = 914,
+            size = ScreenSize.NORMAL,
+            aspect = ScreenAspect.LONG,
+            density = ScreenDensity.DPI_420,
+            name = "MEDIUM_PHONE"
+        )
+    }
+
+    object Tablet {
+        @JvmField
+        val MEDIUM_TABLET = DeviceScreen(
+            widthDp = 1280,
+            heightDp = 800,
+            size = ScreenSize.XLARGE,
+            aspect = ScreenAspect.NOTLONG,
+            density = ScreenDensity.XHDPI,
+            name = "MEDIUM_TABLET"
+        )
+    }
+
+    object Desktop {
+        @JvmField
+        val SMALL_DESKTOP = DeviceScreen(
+            widthDp = 1366,
+            heightDp = 768,
+            size = ScreenSize.XLARGE,
+            aspect = ScreenAspect.LONG,
+            density = ScreenDensity.MDPI,
+            name = "SMALL_DESKTOP"
+        )
+
+        @JvmField
+        val MEDIUM_DESKTOP = DeviceScreen(
+            widthDp = 1920,
+            heightDp = 1080,
+            size = ScreenSize.XLARGE,
+            aspect = ScreenAspect.LONG,
+            density = ScreenDensity.XHDPI,
+            name = "MEDIUM_DESKTOP"
+        )
+
+        @JvmField
+        val LARGE_DESKTOP = DeviceScreen(
+            widthDp = 1920,
+            heightDp = 1080,
+            size = ScreenSize.XLARGE,
+            aspect = ScreenAspect.LONG,
+            density = ScreenDensity.MDPI,
+            name = "LARGE_DESKTOP"
         )
     }
 
@@ -116,6 +191,7 @@ data class DeviceScreen(
             aspect = ScreenAspect.LONG,
             type = ScreenType.TV,
             density = ScreenDensity.XXXHDPI,
+            name = "ANDROID_TV_4k"
         )
 
         @JvmField
@@ -126,6 +202,7 @@ data class DeviceScreen(
             aspect = ScreenAspect.LONG,
             type = ScreenType.TV,
             density = ScreenDensity.XHDPI,
+            name = "ANDROID_TV_1080p"
         )
 
         @JvmField
@@ -136,6 +213,7 @@ data class DeviceScreen(
             aspect = ScreenAspect.LONG,
             type = ScreenType.TV,
             density = ScreenDensity.TVDPI,
+            name = "ANDROID_TV_720p"
         )
     }
 
@@ -148,6 +226,7 @@ data class DeviceScreen(
             round = RoundScreen.NOTROUND,
             type = ScreenType.WATCH,
             density = ScreenDensity.XHDPI,
+            name = "WEAR_OS_SQUARE"
         )
 
         val WEAR_OS_LARGE_ROUND = DeviceScreen(
@@ -158,6 +237,7 @@ data class DeviceScreen(
             round = RoundScreen.ROUND,
             type = ScreenType.WATCH,
             density = ScreenDensity.XHDPI,
+            name = "WEAR_OS_LARGE_ROUND"
         )
 
         val WEAR_OS_SMALL_ROUND = DeviceScreen(
@@ -168,6 +248,7 @@ data class DeviceScreen(
             round = RoundScreen.ROUND,
             type = ScreenType.WATCH,
             density = ScreenDensity.XHDPI,
+            name = "WEAR_OS_SMALL_ROUND"
         )
 
         val WEAR_OS_RECTANGULAR = DeviceScreen(
@@ -178,6 +259,7 @@ data class DeviceScreen(
             round = RoundScreen.NOTROUND,
             type = ScreenType.WATCH,
             density = ScreenDensity.XHDPI,
+            name = "WEAR_OS_RECTANGULAR"
         )
     }
 
@@ -190,6 +272,7 @@ data class DeviceScreen(
             round = RoundScreen.NOTROUND,
             type = ScreenType.CAR,
             density = ScreenDensity.MDPI,
+            name = "ANDROID_AUTO_1024p"
         )
     }
 }

--- a/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/utils/activity/TestDataForActivity.kt
+++ b/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/utils/activity/TestDataForActivity.kt
@@ -1,0 +1,19 @@
+package sergio.sastre.uitesting.robolectric.utils.activity
+
+import sergio.sastre.uitesting.robolectric.config.screen.DeviceScreen
+import sergio.sastre.uitesting.utils.activityscenario.ActivityConfigItem
+
+data class TestDataForActivity<T :Enum<T>>(
+    val uiState: T,
+    val device: DeviceScreen? = null,
+    val config: ActivityConfigItem? = null
+){
+    val screenshotId: String
+        get() = listOfNotNull(
+            uiState.name,
+            config?.id,
+            device?.name
+        )
+            .filter { it.isNotBlank() }
+            .joinToString(separator = "_")
+}

--- a/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/utils/activity/TestDataForActivityCombinator.kt
+++ b/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/utils/activity/TestDataForActivityCombinator.kt
@@ -1,0 +1,45 @@
+package sergio.sastre.uitesting.robolectric.utils.activity
+
+import sergio.sastre.uitesting.robolectric.config.screen.DeviceScreen
+import sergio.sastre.uitesting.utils.activityscenario.ActivityConfigItem
+
+class TestDataForActivityCombinator<T: Enum<T>>(uiStates: Array<T>) {
+
+    private var testConfigItems: Array<TestDataForActivity<T>> = uiStates.map { item ->
+        TestDataForActivity(uiState = item)
+    }.toTypedArray()
+
+    fun forDevices(vararg deviceScreens: DeviceScreen): TestDataForActivityCombinator<T> = apply {
+        val cartesianProductList = mutableListOf<TestDataForActivity<T>>()
+        for (testItem in testConfigItems) {
+            for (deviceScreen in deviceScreens) {
+                cartesianProductList.add(
+                    TestDataForActivity(
+                        uiState = testItem.uiState,
+                        device = deviceScreen,
+                        config = testItem.config
+                    )
+                )
+            }
+        }
+        testConfigItems = cartesianProductList.toTypedArray()
+    }
+
+    fun forConfigs(vararg configs: ActivityConfigItem): TestDataForActivityCombinator<T> = apply {
+        val cartesianProductList = mutableListOf<TestDataForActivity<T>>()
+        for (testItem in testConfigItems) {
+            for (config in configs) {
+                cartesianProductList.add(
+                    TestDataForActivity(
+                        uiState = testItem.uiState,
+                        device = testItem.device,
+                        config = config
+                    )
+                )
+            }
+        }
+        testConfigItems = cartesianProductList.toTypedArray()
+    }
+
+    fun combineAll() : Array<TestDataForActivity<T>> = testConfigItems.copyOf()
+}

--- a/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/utils/composable/TestDataForComposable.kt
+++ b/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/utils/composable/TestDataForComposable.kt
@@ -1,0 +1,19 @@
+package sergio.sastre.uitesting.robolectric.utils.composable
+
+import sergio.sastre.uitesting.robolectric.config.screen.DeviceScreen
+import sergio.sastre.uitesting.utils.activityscenario.ComposableConfigItem
+
+data class TestDataForComposable<T : Enum<T>>(
+    val uiState: T,
+    val device: DeviceScreen? = null,
+    val config: ComposableConfigItem? = null
+) {
+    val screenshotId: String
+        get() = listOfNotNull(
+            uiState.name,
+            config?.id,
+            device?.name
+        )
+            .filter { it.isNotBlank() }
+            .joinToString(separator = "_")
+}

--- a/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/utils/composable/TestDataForComposableCombinator.kt
+++ b/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/utils/composable/TestDataForComposableCombinator.kt
@@ -1,0 +1,45 @@
+package sergio.sastre.uitesting.robolectric.utils.composable
+
+import sergio.sastre.uitesting.robolectric.config.screen.DeviceScreen
+import sergio.sastre.uitesting.utils.activityscenario.ComposableConfigItem
+
+class TestDataForComposableCombinator<T: Enum<T>>(uiStates: Array<T>) {
+
+    private var testDataItems: Array<TestDataForComposable<T>> = uiStates.map { item ->
+        TestDataForComposable(uiState = item)
+    }.toTypedArray()
+
+    fun forDevices(vararg deviceScreens: DeviceScreen): TestDataForComposableCombinator<T> = apply {
+        val cartesianProductList = mutableListOf<TestDataForComposable<T>>()
+        for (testItem in testDataItems) {
+            for (deviceScreen in deviceScreens) {
+                cartesianProductList.add(
+                    TestDataForComposable(
+                        uiState = testItem.uiState,
+                        device = deviceScreen,
+                        config = testItem.config
+                    )
+                )
+            }
+        }
+        testDataItems = cartesianProductList.toTypedArray()
+    }
+
+    fun forConfigs(vararg configs: ComposableConfigItem): TestDataForComposableCombinator<T> = apply {
+        val cartesianProductList = mutableListOf<TestDataForComposable<T>>()
+        for (testItem in testDataItems) {
+            for (config in configs) {
+                cartesianProductList.add(
+                    TestDataForComposable(
+                        uiState = testItem.uiState,
+                        device = testItem.device,
+                        config = config
+                    )
+                )
+            }
+        }
+        testDataItems = cartesianProductList.toTypedArray()
+    }
+
+    fun combineAll() : Array<TestDataForComposable<T>> = testDataItems.copyOf()
+}

--- a/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/utils/fragment/TestDataForFragment.kt
+++ b/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/utils/fragment/TestDataForFragment.kt
@@ -1,0 +1,19 @@
+package sergio.sastre.uitesting.robolectric.utils.fragment
+
+import sergio.sastre.uitesting.robolectric.config.screen.DeviceScreen
+import sergio.sastre.uitesting.utils.fragmentscenario.FragmentConfigItem
+
+data class TestDataForFragment<T :Enum<T>>(
+    val uiState: T,
+    val device: DeviceScreen? = null,
+    val config: FragmentConfigItem? = null
+){
+    val screenshotId: String
+        get() = listOfNotNull(
+            uiState.name,
+            config?.id,
+            device?.name
+        )
+            .filter { it.isNotBlank() }
+            .joinToString(separator = "_")
+}

--- a/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/utils/fragment/TestDataForFragmentCombinator.kt
+++ b/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/utils/fragment/TestDataForFragmentCombinator.kt
@@ -1,0 +1,45 @@
+package sergio.sastre.uitesting.robolectric.utils.fragment
+
+import sergio.sastre.uitesting.robolectric.config.screen.DeviceScreen
+import sergio.sastre.uitesting.utils.fragmentscenario.FragmentConfigItem
+
+class TestDataForFragmentCombinator<T: Enum<T>>(uiStates: Array<T>) {
+
+    private var testConfigItems: Array<TestDataForFragment<T>> = uiStates.map { item ->
+        TestDataForFragment(uiState = item)
+    }.toTypedArray()
+
+    fun forDevices(vararg deviceScreens: DeviceScreen): TestDataForFragmentCombinator<T> = apply {
+        val cartesianProductList = mutableListOf<TestDataForFragment<T>>()
+        for (testItem in testConfigItems) {
+            for (deviceScreen in deviceScreens) {
+                cartesianProductList.add(
+                    TestDataForFragment(
+                        uiState = testItem.uiState,
+                        device = deviceScreen,
+                        config = testItem.config
+                    )
+                )
+            }
+        }
+        testConfigItems = cartesianProductList.toTypedArray()
+    }
+
+    fun forConfigs(vararg configs: FragmentConfigItem): TestDataForFragmentCombinator<T> = apply {
+        val cartesianProductList = mutableListOf<TestDataForFragment<T>>()
+        for (testItem in testConfigItems) {
+            for (config in configs) {
+                cartesianProductList.add(
+                    TestDataForFragment(
+                        uiState = testItem.uiState,
+                        device = testItem.device,
+                        config = config
+                    )
+                )
+            }
+        }
+        testConfigItems = cartesianProductList.toTypedArray()
+    }
+
+    fun combineAll() : Array<TestDataForFragment<T>> = testConfigItems.copyOf()
+}

--- a/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/utils/view/TestDataForView.kt
+++ b/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/utils/view/TestDataForView.kt
@@ -1,0 +1,19 @@
+package sergio.sastre.uitesting.robolectric.utils.view
+
+import sergio.sastre.uitesting.robolectric.config.screen.DeviceScreen
+import sergio.sastre.uitesting.utils.activityscenario.ViewConfigItem
+
+data class TestDataForView<T :Enum<T>>(
+    val uiState: T,
+    val device: DeviceScreen? = null,
+    val config: ViewConfigItem? = null
+){
+    val screenshotId: String
+        get() = listOfNotNull(
+            uiState.name,
+            config?.id,
+            device?.name
+        )
+            .filter { it.isNotBlank() }
+            .joinToString(separator = "_")
+}

--- a/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/utils/view/TestDataForViewCombinator.kt
+++ b/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/utils/view/TestDataForViewCombinator.kt
@@ -1,0 +1,45 @@
+package sergio.sastre.uitesting.robolectric.utils.view
+
+import sergio.sastre.uitesting.robolectric.config.screen.DeviceScreen
+import sergio.sastre.uitesting.utils.activityscenario.ViewConfigItem
+
+class TestDataForViewCombinator<T: Enum<T>>(uiStates: Array<T>) {
+
+    private var testConfigItems: Array<TestDataForView<T>> = uiStates.map { item ->
+        TestDataForView(uiState = item)
+    }.toTypedArray()
+
+    fun forDevices(vararg deviceScreens: DeviceScreen): TestDataForViewCombinator<T> = apply {
+        val cartesianProductList = mutableListOf<TestDataForView<T>>()
+        for (testItem in testConfigItems) {
+            for (deviceScreen in deviceScreens) {
+                cartesianProductList.add(
+                    TestDataForView(
+                        uiState = testItem.uiState,
+                        device = deviceScreen,
+                        config = testItem.config
+                    )
+                )
+            }
+        }
+        testConfigItems = cartesianProductList.toTypedArray()
+    }
+
+    fun forConfigs(vararg configs: ViewConfigItem): TestDataForViewCombinator<T> = apply {
+        val cartesianProductList = mutableListOf<TestDataForView<T>>()
+        for (testItem in testConfigItems) {
+            for (config in configs) {
+                cartesianProductList.add(
+                    TestDataForView(
+                        uiState = testItem.uiState,
+                        device = testItem.device,
+                        config = config
+                    )
+                )
+            }
+        }
+        testConfigItems = cartesianProductList.toTypedArray()
+    }
+
+    fun combineAll() : Array<TestDataForView<T>> = testConfigItems.copyOf()
+}

--- a/roborazzi/build.gradle
+++ b/roborazzi/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdk 23
         targetSdk 33
-        versionCode 21
-        versionName "2.0.0"
+        versionCode 22
+        versionName "2.0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -46,7 +46,7 @@ dependencies {
     implementation project(':robolectric')
     implementation project(':mapper-roborazzi')
 
-    api 'io.github.takahirom.roborazzi:roborazzi:1.5.0-rc-1'
+    api 'io.github.takahirom.roborazzi:roborazzi:1.7.0-rc-1'
     api 'androidx.test.espresso:espresso-core:3.5.1'
     api 'org.hamcrest:hamcrest:2.2'
 
@@ -59,7 +59,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "roborazzi"
-            version = '2.0.0'
+            version = '2.0.1'
 
             afterEvaluate {
                 from components.release

--- a/roborazzi/src/main/java/sergio/sastre/uitesting/roborazzi/RobolectricActivityScenarioForComposableTestRuleExt.kt
+++ b/roborazzi/src/main/java/sergio/sastre/uitesting/roborazzi/RobolectricActivityScenarioForComposableTestRuleExt.kt
@@ -2,6 +2,11 @@ package sergio.sastre.uitesting.roborazzi
 
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.onRoot
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.RoborazziOptions
+import com.github.takahirom.roborazzi.captureRoboImage
+import com.github.takahirom.roborazzi.provideRoborazziContext
 import sergio.sastre.uitesting.robolectric.activityscenario.RobolectricActivityScenarioForComposableRule
 
 fun RobolectricActivityScenarioForComposableRule.setContent(
@@ -13,4 +18,43 @@ fun RobolectricActivityScenarioForComposableRule.setContent(
         }
 
     return this
+}
+
+fun RobolectricActivityScenarioForComposableRule.captureRoboImage(
+    composable: @Composable () -> Unit,
+){
+    activityScenario
+        .onActivity {
+            it.setContent { composable.invoke() }
+        }
+
+    composeRule.onRoot().captureRoboImage()
+}
+
+fun RobolectricActivityScenarioForComposableRule.captureRoboImage(
+    filePath: String,
+    composable: @Composable () -> Unit,
+){
+    activityScenario
+        .onActivity {
+            it.setContent { composable.invoke() }
+        }
+
+    composeRule.onRoot().captureRoboImage(filePath = filePath)
+}
+
+fun RobolectricActivityScenarioForComposableRule.captureRoboImage(
+    filePath: String,
+    roborazziOptions: RoborazziOptions,
+    composable: @Composable () -> Unit,
+){
+    activityScenario
+        .onActivity {
+            it.setContent { composable.invoke() }
+        }
+
+    composeRule.onRoot().captureRoboImage(
+        filePath = filePath,
+        roborazziOptions = roborazziOptions,
+    )
 }

--- a/roborazzi/src/main/java/sergio/sastre/uitesting/roborazzi/config/RoborazziSharedTestAdapter.kt
+++ b/roborazzi/src/main/java/sergio/sastre/uitesting/roborazzi/config/RoborazziSharedTestAdapter.kt
@@ -1,8 +1,9 @@
 package sergio.sastre.uitesting.roborazzi.config
 
+import com.github.takahirom.roborazzi.Dump
+import com.github.takahirom.roborazzi.Dump.Companion.AccessibilityExplanation
+import com.github.takahirom.roborazzi.Dump.Companion.DefaultExplanation
 import com.github.takahirom.roborazzi.RoborazziOptions
-import com.github.takahirom.roborazzi.RoborazziOptions.CaptureType.Dump.Companion.AccessibilityExplanation
-import com.github.takahirom.roborazzi.RoborazziOptions.CaptureType.Dump.Companion.DefaultExplanation
 import sergio.sastre.uitesting.robolectric.config.screen.DeviceScreen
 import sergio.sastre.uitesting.robolectric.config.screen.RoundScreen
 import sergio.sastre.uitesting.robolectric.config.screen.ScreenAspect

--- a/shot/build.gradle
+++ b/shot/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation project(':utils')
     api 'com.karumi:shot-android:6.0.0'
     api 'androidx.activity:activity-compose:1.7.1'
+    implementation 'org.lsposed.hiddenapibypass:hiddenapibypass:4.3'
 }
 
 //https://www.talentica.com/blogs/publish-your-android-library-on-jitpack-for-better-reachability/

--- a/shot/build.gradle
+++ b/shot/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdk 23
         targetSdk 33
-        versionCode 21
-        versionName "2.0.0"
+        versionCode 22
+        versionName "2.0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -54,7 +54,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "shot"
-            version = '2.0.0'
+            version = '2.0.1'
 
             afterEvaluate {
                 from components.release

--- a/shot/src/main/java/sergio/sastre/uitesting/shot/ScreenshotTaker.kt
+++ b/shot/src/main/java/sergio/sastre/uitesting/shot/ScreenshotTaker.kt
@@ -1,11 +1,13 @@
 package sergio.sastre.uitesting.shot
 
 import android.app.Dialog
+import android.os.Build
 import android.view.View
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.core.view.drawToBitmap
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.karumi.shot.ScreenshotTest
+import org.lsposed.hiddenapibypass.HiddenApiBypass
 import sergio.sastre.uitesting.utils.crosslibrary.config.BitmapCaptureMethod
 import sergio.sastre.uitesting.utils.utils.drawToBitmap
 import sergio.sastre.uitesting.utils.utils.drawToBitmapWithElevation
@@ -103,10 +105,24 @@ internal class ScreenshotTaker(
                 bitmap = dialog.drawToBitmapWithElevation(config = bitmapCaptureMethod.config),
                 name = name,
             )
-            null -> screenshotTest.compareScreenshot(
-                dialog = dialog,
-                name = name,
-            )
+            null -> bypassNonSDKInterface {
+                screenshotTest.compareScreenshot(
+                    dialog = dialog,
+                    name = name,
+                )
+            }
+        }
+    }
+
+    // compareScreenshot uses some non-SDK interfaces to take screenshots of dialogs,
+    // so we need to bypass it
+    private fun bypassNonSDKInterface(actionToDo: () -> Unit) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            HiddenApiBypass.addHiddenApiExemptions("")
+        }
+        actionToDo()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            HiddenApiBypass.clearHiddenApiExemptions()
         }
     }
 }

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdk 23
         targetSdk 33
-        versionCode 21
-        versionName "2.0.0"
+        versionCode 22
+        versionName "2.0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -69,7 +69,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "utils"
-            version = '2.0.0'
+            version = '2.0.1'
 
             afterEvaluate {
                 from components.release

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/activityscenario/ActivityConfigItem.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/activityscenario/ActivityConfigItem.kt
@@ -11,4 +11,15 @@ data class ActivityConfigItem(
     val systemLocale: String? = null,
     val fontSize: FontSize? = null,
     val displaySize: DisplaySize? = null,
-)
+) {
+    val id: String
+        get() {
+            val nonNullProperties = mutableListOf<String>()
+            systemLocale?.let { nonNullProperties.add(it.uppercase()) }
+            uiMode?.let { nonNullProperties.add(it.name) }
+            fontSize?.let { nonNullProperties.add("FONT_${it.name}") }
+            displaySize?.let { nonNullProperties.add("DISPLAY_${it.name}") }
+            orientation?.let { nonNullProperties.add(it.name) }
+            return nonNullProperties.joinToString(separator = "_")
+        }
+}

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/activityscenario/ComposableConfigItem.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/activityscenario/ComposableConfigItem.kt
@@ -11,4 +11,15 @@ data class ComposableConfigItem(
     val locale: String? = null,
     val fontSize: FontSize? = null,
     val displaySize: DisplaySize? = null,
-)
+) {
+    val id: String
+        get() {
+            val nonNullProperties = mutableListOf<String>()
+            locale?.let { nonNullProperties.add(it.uppercase()) }
+            uiMode?.let { nonNullProperties.add(it.name) }
+            fontSize?.let { nonNullProperties.add("FONT_${it.name}") }
+            displaySize?.let { nonNullProperties.add("DISPLAY_${it.name}") }
+            orientation?.let { nonNullProperties.add(it.name) }
+            return nonNullProperties.joinToString(separator = "_")
+        }
+}

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/activityscenario/ViewConfigItem.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/activityscenario/ViewConfigItem.kt
@@ -1,6 +1,7 @@
 package sergio.sastre.uitesting.utils.activityscenario
 
 import androidx.annotation.StyleRes
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import sergio.sastre.uitesting.utils.common.DisplaySize
 import sergio.sastre.uitesting.utils.common.FontSize
 import sergio.sastre.uitesting.utils.common.Orientation
@@ -13,4 +14,21 @@ data class ViewConfigItem(
     val fontSize: FontSize? = null,
     val displaySize: DisplaySize? = null,
     @StyleRes val theme: Int? = null,
-)
+) {
+    val id : String
+        get() {
+            val nonNullProperties = mutableListOf<String>()
+            locale?.let { nonNullProperties.add(it.uppercase()) }
+            uiMode?.let { nonNullProperties.add(it.name) }
+            theme?.let {
+                val themeInfo = getInstrumentation().targetContext.resources.getResourceName(it)
+                // The themeInfo will be in the format: "android:style/Theme.XXX"
+                val theme = themeInfo.substring(themeInfo.lastIndexOf('/') + 1)
+                nonNullProperties.add(theme.replace(".","_").uppercase())
+            }
+            fontSize?.let { nonNullProperties.add("FONT_${it.name}") }
+            displaySize?.let { nonNullProperties.add("DISPLAY_${it.name}") }
+            orientation?.let { nonNullProperties.add(it.name) }
+            return nonNullProperties.joinToString(separator = "_")
+        }
+}

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/fragmentscenario/FragmentConfigItem.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/fragmentscenario/FragmentConfigItem.kt
@@ -1,6 +1,7 @@
 package sergio.sastre.uitesting.utils.fragmentscenario
 
 import androidx.annotation.StyleRes
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import sergio.sastre.uitesting.utils.common.DisplaySize
 import sergio.sastre.uitesting.utils.common.FontSize
 import sergio.sastre.uitesting.utils.common.Orientation
@@ -13,4 +14,21 @@ data class FragmentConfigItem(
     val fontSize: FontSize? = null,
     val displaySize: DisplaySize? = null,
     @StyleRes val theme: Int? = null,
-)
+) {
+    val id : String
+        get() {
+            val nonNullProperties = mutableListOf<String>()
+            locale?.let { nonNullProperties.add(it.uppercase()) }
+            uiMode?.let { nonNullProperties.add(it.name) }
+            theme?.let {
+                val themeInfo = getInstrumentation().targetContext.resources.getResourceName(it)
+                // The themeInfo will be in the format: "android:style/Theme.XXX"
+                val theme = themeInfo.substring(themeInfo.lastIndexOf('/') + 1)
+                nonNullProperties.add(theme.replace(".","_").uppercase())
+            }
+            fontSize?.let { nonNullProperties.add("FONT_${it.name}") }
+            displaySize?.let { nonNullProperties.add("DISPLAY_${it.name}") }
+            orientation?.let { nonNullProperties.add(it.name) }
+            return nonNullProperties.joinToString(separator = "_")
+        }
+}


### PR DESCRIPTION
1.  Add support for Robolectric/Roborazzi tests to under multiple devices and configs
```kotlin
companion object {
   @JvmStatic
   @ParameterizedRobolectricTestRunner.Parameters
   fun testItemProvider(): Array<TestDataForComposable<MyEnum>> =
      TestDataForComposableCombinator(
         uiStates = MyEnum.values()
      )
         .forDevices(
            PIXEL_4A,
            MEDIUM_TABLET,
         )
         .forConfigs(
            ComposableConfigItem(uiMode = DAY),
            ComposableConfigItem(uiMode = NIGHT),
         )
         .combineAll()
}
```
2. Easier Roborazzi tests with `RobolectricActivityScenarioForComposable()`
with `com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.0.1` dependency:
```kotlin
robolectricActivityScenarioForComposableRule.captureRoboImage(
   filePath("CoffeeDrinkListComposable_${testItem.screenshotId}")
) {
   AppTheme {
      CoffeeDrinkList(coffeeDrink = testItem.uiState.drink)
   }
}
```
3. More Robolectric devices to use with `RobolectricActivityScenario`s
- Desktops: small, medium and large desktop
- Tablets: medium tablet
- Phones: small and medium phone
