### PR TITLE
prepare release 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ allprojects {
 
 ```groovy
 dependencies {
-    androidTestImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.0.2') {
+    androidTestImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.1.0') {
         // if necessary, add this to avoid compose version clashes
         exclude group: 'androidx.compose.ui'
     }
@@ -164,8 +164,8 @@ Moreover, it offers some utility methods to generate Robolectric screenshot test
 For that, add the following dependencies in your `build.gradle`:
 
 ```kotlin
-testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.0.2'
-testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.0.2'
+testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.1,0'
+testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.1.0'
 ```
 
 If you get any error due to "Activity not found" in your application module, add the following to your `debug/manifest`
@@ -205,8 +205,8 @@ It's possible to configure several libraries though<sup>1</sup>. For shared scre
    It's recommended to use the AndroidUiTestingUtils version that corresponds to the screenshot library version you're using:</br>
 
 | AndroidUiTestingUtils | Roborazzi      | Paparazzi | Dropshots | Shot   | Android-Testify |
-| --------------------- | -------------- | --------- | --------- |--------|-----------------|
-| *2.0.2*               | *1.8.0-alpha-6*|  1.3.1    | 0.4.1     | 6.0.0  | *2.0.0*         |
+|-----------------------| -------------- | --------- | --------- |--------|-----------------|
+| *2.1.0*               | *1.8.0-alpha-6*|  1.3.1    | 0.4.1     | 6.0.0  | *2.0.0*         |
 | 2.0.1                 | 1.7.0-rc-1     |  1.3.1    | 0.4.1     | 6.0.0  | -               |
 | 2.0.0                 | 1.5.0-rc-1     |  1.3.1    | 0.4.1     | 6.0.0  | -               |
 
@@ -960,7 +960,7 @@ class SnapComposableTest {
 ```
 The snapComposable method can be simplified further if adding the following dependency
 ```groovy
-testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.0.2'
+testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.1.0'
 ```
 and then
 ```kotlin

--- a/android-testify/build.gradle
+++ b/android-testify/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdk 23
         targetSdk 33
-        versionCode 25
-        versionName "2.0.2-rc1"
+        versionCode 26
+        versionName "2.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -56,7 +56,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "android-testify"
-            version = '2.0.2-rc1'
+            version = '2.1.0'
 
             afterEvaluate {
                 from components.release

--- a/dropshots/build.gradle
+++ b/dropshots/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdk 23
         targetSdk 33
-        versionCode 25
-        versionName "2.0.2-rc1"
+        versionCode 26
+        versionName "2.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -54,7 +54,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "dropshots"
-            version = '2.0.2-rc1'
+            version = '2.1.0'
 
             afterEvaluate {
                 from components.release

--- a/mapper-paparazzi/build.gradle
+++ b/mapper-paparazzi/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdk 23
         targetSdk 33
-        versionCode 25
-        versionName "2.0.2-rc1"
+        versionCode 26
+        versionName "2.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -42,7 +42,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "mapper-paparazzi"
-            version = '2.0.2-rc1'
+            version = '2.1.0'
 
             afterEvaluate {
                 from components.release

--- a/mapper-roborazzi/build.gradle
+++ b/mapper-roborazzi/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdk 23
         targetSdk 33
-        versionCode 25
-        versionName "2.0.2-rc1"
+        versionCode 26
+        versionName "2.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -43,7 +43,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "mapper-roborazzi"
-            version = '2.0.2-rc1'
+            version = '2.1.0'
 
             afterEvaluate {
                 from components.release

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdk 23
         targetSdk 33
-        versionCode 25
-        versionName "2.0.2-rc1"
+        versionCode 26
+        versionName "2.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -52,7 +52,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "paparazzi"
-            version = '2.0.2-rc1'
+            version = '2.1.0'
 
             afterEvaluate {
                 from components.release

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdk 23
         targetSdk 33
-        versionCode 25
-        versionName "2.0.2-rc1"
+        versionCode 26
+        versionName "2.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -43,7 +43,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "robolectric"
-            version = '2.0.2-rc1'
+            version = '2.1.0'
 
             afterEvaluate {
                 from components.release

--- a/roborazzi/build.gradle
+++ b/roborazzi/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdk 23
         targetSdk 33
-        versionCode 25
-        versionName "2.0.2-rc1"
+        versionCode 26
+        versionName "2.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -59,7 +59,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "roborazzi"
-            version = '2.0.2-rc1'
+            version = '2.1.0'
 
             afterEvaluate {
                 from components.release

--- a/shot/build.gradle
+++ b/shot/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdk 23
         targetSdk 33
-        versionCode 25
-        versionName "2.0.2-rc1"
+        versionCode 26
+        versionName "2.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -54,7 +54,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "shot"
-            version = '2.0.2-rc1'
+            version = '2.1.0'
 
             afterEvaluate {
                 from components.release

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdk 23
         targetSdk 33
-        versionCode 25
-        versionName "2.0.2-rc1"
+        versionCode 26
+        versionName "2.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -69,7 +69,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "utils"
-            version = '2.0.2-rc1'
+            version = '2.1.0'
 
             afterEvaluate {
                 from components.release


### PR DESCRIPTION
Cross-Library Screenshot Tests updates:
- Android-Testify support, which supports screenshot testing with Gradle Managed Devices
- Update Roborazzi to 1.8.0-alpha-6 & added ComparisonStyle.Grid support

Others
- Add DisableAnimationsTestRule