### PR TITLE
Release 2.3.0

### DIFF
--- a/android-testify/build.gradle
+++ b/android-testify/build.gradle
@@ -62,7 +62,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "android-testify"
-            version = '2.2.1'
+            version = '2.3.0'
 
             afterEvaluate {
                 from components.release

--- a/dropshots/build.gradle
+++ b/dropshots/build.gradle
@@ -61,7 +61,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "dropshots"
-            version = '2.2.1'
+            version = '2.3.0'
 
             afterEvaluate {
                 from components.release

--- a/mapper-paparazzi/build.gradle
+++ b/mapper-paparazzi/build.gradle
@@ -49,7 +49,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "mapper-paparazzi"
-            version = '2.2.1'
+            version = '2.3.0'
 
             afterEvaluate {
                 from components.release

--- a/mapper-paparazzi/src/main/java/sergio/sastre/uitesting/mapper/paparazzi/wrapper/Environment.kt
+++ b/mapper-paparazzi/src/main/java/sergio/sastre/uitesting/mapper/paparazzi/wrapper/Environment.kt
@@ -6,8 +6,6 @@ data class Environment(
     val platformDir: String? = null,
     val compileSdkVersion: Int? = null,
     val appTestDir: String? = null,
-    val resDir: String? = null,
-    val assetsDir: String? = null,
     val packageName: String? = null,
     val resourcePackageNames: List<String>? = null,
     val localResourceDirs: List<String>? = null,

--- a/mapper-roborazzi/build.gradle
+++ b/mapper-roborazzi/build.gradle
@@ -50,7 +50,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "mapper-roborazzi"
-            version = '2.2.1'
+            version = '2.3.0'
 
             afterEvaluate {
                 from components.release

--- a/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/CompareOptions.kt
+++ b/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/CompareOptions.kt
@@ -1,9 +1,16 @@
 package sergio.sastre.uitesting.mapper.roborazzi.wrapper
 
 data class CompareOptions(
-    val changeThreshold: Float = 0.01F,
+    val changeThreshold: Float = 0.0F,
     val outputDirectoryPath: String = DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH,
     val comparisonStyle: ComparisonStyle = ComparisonStyle.Grid(),
+    val simpleImageComparator: SimpleImageComparator = SimpleImageComparator()
+)
+
+class SimpleImageComparator(
+    val maxDistance: Float = 0.007F,
+    val hShift: Int = 0,
+    val vShift: Int = 0,
 )
 
 sealed interface ComparisonStyle {
@@ -13,7 +20,7 @@ sealed interface ComparisonStyle {
         val hasLabel: Boolean = true
     ) : ComparisonStyle
 
-    object Simple : ComparisonStyle
+    data object Simple : ComparisonStyle
 }
 
 const val DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH = "build/outputs/roborazzi"

--- a/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/RoborazziOptions.kt
+++ b/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/RoborazziOptions.kt
@@ -3,4 +3,5 @@ package sergio.sastre.uitesting.mapper.roborazzi.wrapper
 data class RoborazziOptions(
     val captureType: CaptureType = CaptureType.Screenshot,
     val compareOptions: CompareOptions = CompareOptions(),
+    val contextData: Map<String, Any> = emptyMap(),
 )

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -57,7 +57,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "paparazzi"
-            version = '2.2.1'
+            version = '2.3.0'
 
             afterEvaluate {
                 from components.release

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -48,7 +48,7 @@ android {
 dependencies {
     implementation project(':utils')
     api project(':mapper-paparazzi')
-    api('app.cash.paparazzi:paparazzi:1.3.2')
+    api('app.cash.paparazzi:paparazzi:1.3.3')
 }
 
 //https://www.talentica.com/blogs/publish-your-android-library-on-jitpack-for-better-reachability/

--- a/paparazzi/src/main/java/sergio/sastre/uitesting/paparazzi/config/PaparazziScreenshotConfigAdapter.kt
+++ b/paparazzi/src/main/java/sergio/sastre/uitesting/paparazzi/config/PaparazziScreenshotConfigAdapter.kt
@@ -18,7 +18,7 @@ internal class PaparazziScreenshotConfigAdapter(
         PaparazziWrapperConfigAdapter(paparazziConfig).asPaparazziDeviceConfig().copy(
             orientation = screenshotConfigForComposable.orientation.toScreenOrientation(),
             nightMode = screenshotConfigForComposable.uiMode.toNightMode(),
-            fontScale = screenshotConfigForComposable.fontScale.value.toFloat(),
+            fontScale = screenshotConfigForComposable.fontScale.scale,
             locale = screenshotConfigForComposable.locale.toBC47Locale(),
         ).hackViewDimensionsToOrientation()
 
@@ -26,7 +26,7 @@ internal class PaparazziScreenshotConfigAdapter(
         PaparazziWrapperConfigAdapter(paparazziConfig).asPaparazziDeviceConfig().copy(
             orientation = screenshotConfigForView.orientation.toScreenOrientation(),
             nightMode = screenshotConfigForView.uiMode.toNightMode(),
-            fontScale = screenshotConfigForView.fontSize.value.toFloat(),
+            fontScale = screenshotConfigForView.fontSize.scale,
             locale = screenshotConfigForView.locale.toBC47Locale(),
         ).hackViewDimensionsToOrientation()
 

--- a/paparazzi/src/main/java/sergio/sastre/uitesting/paparazzi/config/PaparazziWrapperConfigAdapter.kt
+++ b/paparazzi/src/main/java/sergio/sastre/uitesting/paparazzi/config/PaparazziWrapperConfigAdapter.kt
@@ -103,8 +103,6 @@ internal class PaparazziWrapperConfigAdapter(
             compileSdkVersion = configEnvironment?.compileSdkVersion
                 ?: environment.compileSdkVersion,
             appTestDir = configEnvironment?.appTestDir ?: environment.appTestDir,
-            resDir = configEnvironment?.resDir ?: environment.resDir,
-            assetsDir = configEnvironment?.assetsDir ?: environment.assetsDir,
             packageName = configEnvironment?.packageName ?: environment.packageName,
             resourcePackageNames = configEnvironment?.resourcePackageNames
                 ?: environment.resourcePackageNames,

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -50,7 +50,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "robolectric"
-            version = '2.2.1'
+            version = '2.3.0'
 
             afterEvaluate {
                 from components.release

--- a/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/activityscenario/RobolectricActivityScenarioConfigurator.kt
+++ b/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/activityscenario/RobolectricActivityScenarioConfigurator.kt
@@ -16,18 +16,18 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.android.controller.ActivityController
 import sergio.sastre.uitesting.robolectric.config.RobolectricQualifiersBuilder.setQualifiers
 import sergio.sastre.uitesting.robolectric.config.screen.DeviceScreen
-import sergio.sastre.uitesting.utils.common.FontSize
 import sergio.sastre.uitesting.utils.common.LocaleUtil
 import sergio.sastre.uitesting.utils.common.Orientation
 import sergio.sastre.uitesting.utils.common.UiMode
 import sergio.sastre.uitesting.utils.common.DisplaySize
+import sergio.sastre.uitesting.utils.common.FontSizeScale
 import java.util.*
 
 object RobolectricActivityScenarioConfigurator {
 
     internal data class State(
         var deviceScreen: DeviceScreen? = null,
-        var fontSize: FontSize? = null,
+        var fontSize: FontSizeScale? = null,
         var locale: Locale? = null,
         var orientation: Orientation? = null,
         var uiMode: UiMode? = null,
@@ -58,7 +58,7 @@ object RobolectricActivityScenarioConfigurator {
         val newConfig = this@applyState
         state.apply {
             orientation?.let { newConfig.orientation = it.activityInfo }
-            fontSize?.let { newConfig.fontScale = it.value.toFloat() }
+            fontSize?.let { newConfig.fontScale = it.scale }
             displaySize?.let {
                 val newDensityDpi = it.value.toFloat() * newConfig.densityDpi
                 newConfig.densityDpi = newDensityDpi.toInt()
@@ -110,7 +110,7 @@ object RobolectricActivityScenarioConfigurator {
             state = state.copy(deviceScreen = deviceScreen)
         }
 
-        fun setFontSize(fontSize: FontSize): ForView = apply {
+        fun setFontSize(fontSize: FontSizeScale): ForView = apply {
             state = state.copy(fontSize = fontSize)
         }
 
@@ -190,7 +190,7 @@ object RobolectricActivityScenarioConfigurator {
             state = state.copy(deviceScreen = deviceScreen)
         }
 
-        fun setFontSize(fontSize: FontSize): ForComposable = apply {
+        fun setFontSize(fontSize: FontSizeScale): ForComposable = apply {
             state = state.copy(fontSize = fontSize)
         }
 
@@ -259,7 +259,7 @@ object RobolectricActivityScenarioConfigurator {
             state = state.copy(deviceScreen = deviceScreen)
         }
 
-        fun setFontSize(fontSize: FontSize): ForActivity = apply {
+        fun setFontSize(fontSize: FontSizeScale): ForActivity = apply {
             state = state.copy(fontSize = fontSize)
         }
 

--- a/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/fragmentscenario/RobolectricFragmentScenarioConfigurator.kt
+++ b/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/fragmentscenario/RobolectricFragmentScenarioConfigurator.kt
@@ -32,7 +32,7 @@ import sergio.sastre.uitesting.robolectric.activityscenario.RobolectricActivityS
 import sergio.sastre.uitesting.robolectric.config.RobolectricQualifiersBuilder.setQualifiers
 import sergio.sastre.uitesting.robolectric.config.screen.DeviceScreen
 import sergio.sastre.uitesting.utils.common.DisplaySize
-import sergio.sastre.uitesting.utils.common.FontSize
+import sergio.sastre.uitesting.utils.common.FontSizeScale
 import sergio.sastre.uitesting.utils.common.LocaleUtil
 import sergio.sastre.uitesting.utils.common.Orientation
 import sergio.sastre.uitesting.utils.common.UiMode
@@ -185,7 +185,7 @@ class RobolectricFragmentScenarioConfigurator<F : Fragment> constructor(
     class ForFragment() {
         data class State(
             var deviceScreen: DeviceScreen? = null,
-            var fontSize: FontSize? = null,
+            var fontSize: FontSizeScale? = null,
             var locale: Locale? = null,
             var orientation: Orientation? = null,
             var uiMode: UiMode? = null,
@@ -223,7 +223,7 @@ class RobolectricFragmentScenarioConfigurator<F : Fragment> constructor(
             state = state.copy(uiMode = uiMode)
         }
 
-        fun setFontSize(fontSize: FontSize) = apply {
+        fun setFontSize(fontSize: FontSizeScale) = apply {
             state = state.copy(fontSize = fontSize)
         }
 

--- a/roborazzi/build.gradle
+++ b/roborazzi/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation project(':robolectric')
     implementation project(':mapper-roborazzi')
 
-    api 'io.github.takahirom.roborazzi:roborazzi:1.8.0-alpha-6'
+    api 'io.github.takahirom.roborazzi:roborazzi:1.10.1'
     api 'androidx.test.espresso:espresso-core:3.5.1'
     api 'org.hamcrest:hamcrest:2.2'
 

--- a/roborazzi/build.gradle
+++ b/roborazzi/build.gradle
@@ -64,7 +64,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "roborazzi"
-            version = '2.2.1'
+            version = '2.3.0'
 
             afterEvaluate {
                 from components.release

--- a/roborazzi/src/main/java/sergio/sastre/uitesting/roborazzi/config/RoborazziSharedTestAdapter.kt
+++ b/roborazzi/src/main/java/sergio/sastre/uitesting/roborazzi/config/RoborazziSharedTestAdapter.kt
@@ -1,5 +1,7 @@
 package sergio.sastre.uitesting.roborazzi.config
 
+import com.dropbox.differ.ImageComparator
+import com.dropbox.differ.SimpleImageComparator
 import com.github.takahirom.roborazzi.Dump
 import com.github.takahirom.roborazzi.Dump.Companion.AccessibilityExplanation
 import com.github.takahirom.roborazzi.Dump.Companion.DefaultExplanation
@@ -66,12 +68,14 @@ internal class RoborazziSharedTestAdapter(
                 RoborazziOptions.CompareOptions(
                     outputDirectoryPath = it.compareOptions.outputDirectoryPath,
                     resultValidator = ThresholdValidator(it.compareOptions.changeThreshold),
-                    comparisonStyle = asComparisonStyle()
+                    comparisonStyle = asComparisonStyle(),
+                    imageComparator = asImageComparator(),
                 )
 
             return RoborazziOptions(
                 captureType = adaptedCaptureType,
-                compareOptions = adaptedCompareOptions
+                compareOptions = adaptedCompareOptions,
+                contextData = it.contextData,
             )
         }
     }
@@ -89,6 +93,15 @@ internal class RoborazziSharedTestAdapter(
 
             ComparisonStyle.Simple -> RoborazziOptions.CompareOptions.ComparisonStyle.Simple
         }
+
+    private fun asImageComparator(): ImageComparator {
+        val imageComparator = roborazziConfig.roborazziOptions.compareOptions.simpleImageComparator
+        return SimpleImageComparator(
+            maxDistance = imageComparator.maxDistance,
+            hShift = imageComparator.hShift,
+            vShift = imageComparator.vShift,
+        )
+    }
 
     private fun asDefaultOrientation(): ScreenOrientation =
         config?.let {

--- a/shot/build.gradle
+++ b/shot/build.gradle
@@ -61,7 +61,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "shot"
-            version = '2.2.1'
+            version = '2.3.0'
 
             afterEvaluate {
                 from components.release

--- a/shot/build.gradle
+++ b/shot/build.gradle
@@ -50,7 +50,7 @@ android {
 
 dependencies {
     implementation project(':utils')
-    api 'com.karumi:shot-android:6.0.0'
+    api 'com.karumi:shot-android:6.1.0'
     api 'androidx.activity:activity-compose:1.8.2'
     implementation 'org.lsposed.hiddenapibypass:hiddenapibypass:4.3'
 }

--- a/shot/src/main/java/sergio/sastre/uitesting/shot/ScreenshotTaker.kt
+++ b/shot/src/main/java/sergio/sastre/uitesting/shot/ScreenshotTaker.kt
@@ -39,6 +39,7 @@ internal class ScreenshotTaker(
         view: View,
         bitmapCaptureMethod: BitmapCaptureMethod?,
         name: String?,
+        maxPixels: Long,
     ) {
         compareScreenshot(
             view = view,
@@ -47,7 +48,8 @@ internal class ScreenshotTaker(
             onNoBitmapCapturedMethod = {
                 screenshotTest.compareScreenshot(
                     view = view,
-                    name = name
+                    name = name,
+                    maxPixels = maxPixels,
                 )
             }
         )
@@ -76,6 +78,7 @@ internal class ScreenshotTaker(
         viewHolder: ViewHolder,
         bitmapCaptureMethod: BitmapCaptureMethod?,
         name: String?,
+        maxPixels: Long,
     ) {
         compareScreenshot(
             view = viewHolder.itemView,
@@ -86,6 +89,7 @@ internal class ScreenshotTaker(
                     holder = viewHolder,
                     heightInPx = viewHolder.itemView.measuredHeight,
                     name = name,
+                    maxPixels = maxPixels,
                 )
             }
         )
@@ -95,6 +99,7 @@ internal class ScreenshotTaker(
         dialog: Dialog,
         bitmapCaptureMethod: BitmapCaptureMethod?,
         name: String?,
+        maxPixels: Long,
     ) {
         when (bitmapCaptureMethod) {
             is BitmapCaptureMethod.Canvas -> screenshotTest.compareScreenshot(
@@ -109,6 +114,7 @@ internal class ScreenshotTaker(
                 screenshotTest.compareScreenshot(
                     dialog = dialog,
                     name = name,
+                    maxPixels = maxPixels,
                 )
             }
         }

--- a/shot/src/main/java/sergio/sastre/uitesting/shot/ShotConfig.kt
+++ b/shot/src/main/java/sergio/sastre/uitesting/shot/ShotConfig.kt
@@ -4,9 +4,16 @@ import androidx.annotation.ColorInt
 import sergio.sastre.uitesting.utils.crosslibrary.config.BitmapCaptureMethod
 import sergio.sastre.uitesting.utils.crosslibrary.config.LibraryConfig
 
+/**
+ * @param viewMaxPixels: Max Pixels for the generated screenshot before throwing an exception.
+ * WARNING:
+ *    1. Requires bitmapCaptureMethod = null
+ *    2. Works only with Views, not with Composables
+ */
 class ShotConfig(
     val ignoredViews: List<Int> = emptyList(),
     val prepareUIForScreenshot: () -> Unit = {},
     val bitmapCaptureMethod: BitmapCaptureMethod? = null,
     @ColorInt val backgroundColor: Int? = null,
+    val viewMaxPixels: Long = 10_000_000L,
 ): LibraryConfig

--- a/shot/src/main/java/sergio/sastre/uitesting/shot/ShotScreenshotTestRuleForView.kt
+++ b/shot/src/main/java/sergio/sastre/uitesting/shot/ShotScreenshotTestRuleForView.kt
@@ -51,6 +51,7 @@ class ShotScreenshotTestRuleForView(
             dialog = dialog,
             bitmapCaptureMethod = shotConfig.bitmapCaptureMethod,
             name = name,
+            maxPixels = shotConfig.viewMaxPixels
         )
     }
 
@@ -59,6 +60,7 @@ class ShotScreenshotTestRuleForView(
             view = view,
             bitmapCaptureMethod = shotConfig.bitmapCaptureMethod,
             name = name,
+            maxPixels = shotConfig.viewMaxPixels
         )
     }
 
@@ -67,6 +69,7 @@ class ShotScreenshotTestRuleForView(
             viewHolder = viewHolder,
             bitmapCaptureMethod = shotConfig.bitmapCaptureMethod,
             name = name,
+            maxPixels = shotConfig.viewMaxPixels
         )
     }
 

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -73,7 +73,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "utils"
-            version = '2.2.1'
+            version = '2.3.0'
 
             afterEvaluate {
                 from components.release

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/activityscenario/ActivityConfigItem.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/activityscenario/ActivityConfigItem.kt
@@ -1,7 +1,7 @@
 package sergio.sastre.uitesting.utils.activityscenario
 
 import sergio.sastre.uitesting.utils.common.DisplaySize
-import sergio.sastre.uitesting.utils.common.FontSize
+import sergio.sastre.uitesting.utils.common.FontSizeScale
 import sergio.sastre.uitesting.utils.common.Orientation
 import sergio.sastre.uitesting.utils.common.UiMode
 
@@ -9,7 +9,7 @@ data class ActivityConfigItem(
     val orientation: Orientation? = null,
     val uiMode: UiMode? = null,
     val systemLocale: String? = null,
-    val fontSize: FontSize? = null,
+    val fontSize: FontSizeScale? = null,
     val displaySize: DisplaySize? = null,
 ) {
     val id: String
@@ -17,7 +17,7 @@ data class ActivityConfigItem(
             val nonNullProperties = mutableListOf<String>()
             systemLocale?.let { nonNullProperties.add(it.uppercase()) }
             uiMode?.let { nonNullProperties.add(it.name) }
-            fontSize?.let { nonNullProperties.add("FONT_${it.name}") }
+            fontSize?.let { nonNullProperties.add("FONT_${it.valueAsName()}") }
             displaySize?.let { nonNullProperties.add("DISPLAY_${it.name}") }
             orientation?.let { nonNullProperties.add(it.name) }
             return nonNullProperties.joinToString(separator = "_")

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/activityscenario/ActivityScenarioConfigurator.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/activityscenario/ActivityScenarioConfigurator.kt
@@ -14,16 +14,16 @@ import androidx.annotation.StyleRes
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.fragment.app.FragmentActivity
 import androidx.test.core.app.ActivityScenario
-import sergio.sastre.uitesting.utils.common.FontSize
 import sergio.sastre.uitesting.utils.common.LocaleUtil
 import sergio.sastre.uitesting.utils.common.Orientation
 import sergio.sastre.uitesting.utils.common.UiMode
 import sergio.sastre.uitesting.utils.activityscenario.orientation.OrientationTestWatcher
 import sergio.sastre.uitesting.utils.common.DisplaySize
+import sergio.sastre.uitesting.utils.common.FontSizeScale
 import java.util.*
 
 object ActivityScenarioConfigurator {
-    private var fontSize: FontSize? = null
+    private var fontSize: FontSizeScale? = null
     private var locale: Locale? = null
     private var orientation: Orientation? = null
     private var uiMode: UiMode? = null
@@ -48,7 +48,7 @@ object ActivityScenarioConfigurator {
      *  that purpose.
      */
     class ForView {
-        fun setFontSize(fontSize: FontSize): ForView = apply {
+        fun setFontSize(fontSize: FontSizeScale): ForView = apply {
             ActivityScenarioConfigurator.fontSize = fontSize
         }
 
@@ -103,7 +103,7 @@ object ActivityScenarioConfigurator {
      *
      */
     class ForComposable {
-        fun setFontSize(fontSize: FontSize): ForComposable = apply {
+        fun setFontSize(fontSize: FontSizeScale): ForComposable = apply {
             ActivityScenarioConfigurator.fontSize = fontSize
         }
 
@@ -210,7 +210,7 @@ object ActivityScenarioConfigurator {
     private fun Context.wrap(): Context {
         val newConfig = Configuration(resources.configuration)
 
-        fontSize?.run { newConfig.fontScale = value.toFloat() }
+        fontSize?.run { newConfig.fontScale = this.scale }
         locale?.run { newConfig.setLocale(this) }
         uiMode?.run { newConfig.uiMode = this.configurationInt }
         displaySize?.run {

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/activityscenario/ComposableConfigItem.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/activityscenario/ComposableConfigItem.kt
@@ -1,7 +1,7 @@
 package sergio.sastre.uitesting.utils.activityscenario
 
 import sergio.sastre.uitesting.utils.common.DisplaySize
-import sergio.sastre.uitesting.utils.common.FontSize
+import sergio.sastre.uitesting.utils.common.FontSizeScale
 import sergio.sastre.uitesting.utils.common.Orientation
 import sergio.sastre.uitesting.utils.common.UiMode
 
@@ -9,7 +9,7 @@ data class ComposableConfigItem(
     val orientation: Orientation? = null,
     val uiMode: UiMode? = null,
     val locale: String? = null,
-    val fontSize: FontSize? = null,
+    val fontSize: FontSizeScale? = null,
     val displaySize: DisplaySize? = null,
 ) {
     val id: String
@@ -17,7 +17,7 @@ data class ComposableConfigItem(
             val nonNullProperties = mutableListOf<String>()
             locale?.let { nonNullProperties.add(it.uppercase()) }
             uiMode?.let { nonNullProperties.add(it.name) }
-            fontSize?.let { nonNullProperties.add("FONT_${it.name}") }
+            fontSize?.let { nonNullProperties.add("FONT_${it.valueAsName()}") }
             displaySize?.let { nonNullProperties.add("DISPLAY_${it.name}") }
             orientation?.let { nonNullProperties.add(it.name) }
             return nonNullProperties.joinToString(separator = "_")

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/activityscenario/ViewConfigItem.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/activityscenario/ViewConfigItem.kt
@@ -4,6 +4,7 @@ import androidx.annotation.StyleRes
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import sergio.sastre.uitesting.utils.common.DisplaySize
 import sergio.sastre.uitesting.utils.common.FontSize
+import sergio.sastre.uitesting.utils.common.FontSizeScale
 import sergio.sastre.uitesting.utils.common.Orientation
 import sergio.sastre.uitesting.utils.common.UiMode
 
@@ -11,7 +12,7 @@ data class ViewConfigItem(
     val orientation: Orientation? = null,
     val uiMode: UiMode? = null,
     val locale: String? = null,
-    val fontSize: FontSize? = null,
+    val fontSize: FontSizeScale? = null,
     val displaySize: DisplaySize? = null,
     @StyleRes val theme: Int? = null,
 ) {
@@ -26,7 +27,7 @@ data class ViewConfigItem(
                 val theme = themeInfo.substring(themeInfo.lastIndexOf('/') + 1)
                 nonNullProperties.add(theme.replace(".","_").uppercase())
             }
-            fontSize?.let { nonNullProperties.add("FONT_${it.name}") }
+            fontSize?.let { nonNullProperties.add("FONT_${it.valueAsName()}") }
             displaySize?.let { nonNullProperties.add("DISPLAY_${it.name}") }
             orientation?.let { nonNullProperties.add(it.name) }
             return nonNullProperties.joinToString(separator = "_")

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/common/FontSize.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/common/FontSize.kt
@@ -10,8 +10,21 @@ interface FontSizeScale {
     companion object {
         fun supportedValuesForCurrentSdk(): Array<FontSizeScale> =
             when (SDK_INT >= UPSIDE_DOWN_CAKE) {
-                true -> FontSizeNonLinear.entries.toTypedArray()
-                false -> FontSizeLinear.entries.toTypedArray()
+                true -> arrayOf(
+                    FontSize.SMALL,
+                    FontSize.NORMAL,
+                    FontSize.LARGE,
+                    FontSize.XLARGE,
+                    FontSize.XXLARGE,
+                    FontSize.XXXLARGE,
+                    FontSize.LARGEST
+                )
+                false -> arrayOf(
+                    FontSize.SMALL,
+                    FontSize.NORMAL,
+                    FontSize.LARGE,
+                    FontSize.LARGEST
+                )
             }
     }
 
@@ -30,7 +43,7 @@ private const val MAX_LINEAR_FONT_SCALE = 1.3f
 private const val MAX_NON_LINEAR_FONT_SCALE = 2.0f
 
 enum class FontSize(override val scale: Float) : FontSizeScale {
-    @Discouraged("Use XLARGE or MAXIMUM_LINEAR instead")
+    @Discouraged("Use LARGEST instead. Alternatively, also XLARGE or MAXIMUM_LINEAR")
     HUGE(MAX_LINEAR_FONT_SCALE),
 
     SMALL(0.85f),
@@ -47,26 +60,6 @@ enum class FontSize(override val scale: Float) : FontSizeScale {
     val value: String = scale.toString()
 }
 
-enum class FontSizeLinear(override val scale: Float) : FontSizeScale {
-    SMALL(0.85f),
-    NORMAL(1f),
-    LARGE(1.15f),
-    LARGEST(MAX_LINEAR_FONT_SCALE);
-
-    val value: String = scale.toString()
-}
-
-enum class FontSizeNonLinear(override val scale: Float) : FontSizeScale {
-    SMALL(0.85f),
-    NORMAL(1f),
-    LARGE(1.15f),
-    XLARGE(1.3f),
-    XXLARGE(1.5f),
-    XXXLARGE(1.8f),
-    LARGEST(MAX_NON_LINEAR_FONT_SCALE);
-
-    val value: String = scale.toString()
-}
 
 private val maxFontSizeScaleSupported =
     when (SDK_INT >= UPSIDE_DOWN_CAKE) {

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/common/FontSize.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/common/FontSize.kt
@@ -1,20 +1,81 @@
 package sergio.sastre.uitesting.utils.common
 
-enum class FontSize(val value: String) {
-    SMALL(0.85f.toString()),
-    NORMAL(1f.toString()),
-    LARGE(1.15f.toString()),
-    HUGE(1.3f.toString());
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+import androidx.annotation.Discouraged
+import org.junit.Assume
+
+interface FontSizeScale {
 
     companion object {
-        @JvmStatic
-        fun from(scale: Float): FontSize {
-            for (fontScale in values()) {
-                if (fontScale.value == scale.toString()) {
-                    return fontScale
-                }
+        fun supportedValuesForCurrentSdk(): Array<FontSizeScale> =
+            when (SDK_INT >= UPSIDE_DOWN_CAKE) {
+                true -> FontSizeNonLinear.entries.toTypedArray()
+                false -> FontSizeLinear.entries.toTypedArray()
             }
-            throw IllegalArgumentException("Unknown font scale: $scale")
+    }
+
+    val scale: Float
+
+    fun valueAsName(): String =
+        when (this is Enum<*>) {
+            true -> this.name
+            false -> this.scale.toString().replace(".", "_") + "f"
         }
+
+    class Value(override val scale: Float) : FontSizeScale
+}
+
+private const val MAX_LINEAR_FONT_SCALE = 1.3f
+private const val MAX_NON_LINEAR_FONT_SCALE = 2.0f
+
+enum class FontSize(override val scale: Float) : FontSizeScale {
+    @Discouraged("Use XLARGE or MAXIMUM_LINEAR instead")
+    HUGE(MAX_LINEAR_FONT_SCALE),
+
+    SMALL(0.85f),
+    NORMAL(1f),
+    LARGE(1.15f),
+    XLARGE(MAX_LINEAR_FONT_SCALE),
+    XXLARGE(1.5f),
+    XXXLARGE(1.8f),
+    LARGEST(maxFontSizeScaleSupported),
+
+    MAXIMUM_LINEAR(MAX_LINEAR_FONT_SCALE),
+    MAXIMUM_NON_LINEAR(MAX_NON_LINEAR_FONT_SCALE);
+
+    val value: String = scale.toString()
+}
+
+enum class FontSizeLinear(override val scale: Float) : FontSizeScale {
+    SMALL(0.85f),
+    NORMAL(1f),
+    LARGE(1.15f),
+    LARGEST(MAX_LINEAR_FONT_SCALE);
+
+    val value: String = scale.toString()
+}
+
+enum class FontSizeNonLinear(override val scale: Float) : FontSizeScale {
+    SMALL(0.85f),
+    NORMAL(1f),
+    LARGE(1.15f),
+    XLARGE(1.3f),
+    XXLARGE(1.5f),
+    XXXLARGE(1.8f),
+    LARGEST(MAX_NON_LINEAR_FONT_SCALE);
+
+    val value: String = scale.toString()
+}
+
+private val maxFontSizeScaleSupported =
+    when (SDK_INT >= UPSIDE_DOWN_CAKE) {
+        true -> MAX_NON_LINEAR_FONT_SCALE
+        false -> MAX_LINEAR_FONT_SCALE
+    }
+
+fun assumeSdkSupports(fontSizeScale: FontSizeScale?) {
+    fontSizeScale?.scale?.run {
+        Assume.assumeTrue(this <= maxFontSizeScaleSupported)
     }
 }

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/crosslibrary/config/ScreenshotConfigForComposable.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/crosslibrary/config/ScreenshotConfigForComposable.kt
@@ -3,6 +3,7 @@ package sergio.sastre.uitesting.utils.crosslibrary.config
 import sergio.sastre.uitesting.utils.activityscenario.ComposableConfigItem
 import sergio.sastre.uitesting.utils.common.DisplaySize
 import sergio.sastre.uitesting.utils.common.FontSize
+import sergio.sastre.uitesting.utils.common.FontSizeScale
 import sergio.sastre.uitesting.utils.common.Orientation
 import sergio.sastre.uitesting.utils.common.UiMode
 
@@ -21,7 +22,7 @@ import sergio.sastre.uitesting.utils.common.UiMode
 class ScreenshotConfigForComposable(
     val orientation: Orientation = Orientation.PORTRAIT,
     val uiMode: UiMode = UiMode.DAY,
-    val fontScale: FontSize = FontSize.NORMAL,
+    val fontScale: FontSizeScale = FontSize.NORMAL,
     val locale: String = "en",
     val displaySize: DisplaySize = DisplaySize.NORMAL,
 ) {

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/crosslibrary/config/ScreenshotConfigForView.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/crosslibrary/config/ScreenshotConfigForView.kt
@@ -6,9 +6,9 @@ import androidx.test.platform.app.InstrumentationRegistry
 import sergio.sastre.uitesting.utils.activityscenario.ViewConfigItem
 import sergio.sastre.uitesting.utils.common.DisplaySize
 import sergio.sastre.uitesting.utils.common.FontSize
+import sergio.sastre.uitesting.utils.common.FontSizeScale
 import sergio.sastre.uitesting.utils.common.Orientation
 import sergio.sastre.uitesting.utils.common.UiMode
-import java.lang.StringBuilder
 
 /**
  * Configuration that all screenshot libraries support for cross-library screenshot tests.
@@ -29,7 +29,7 @@ data class ScreenshotConfigForView(
     val orientation: Orientation = Orientation.PORTRAIT,
     val uiMode: UiMode = UiMode.DAY,
     val locale: String = "en",
-    val fontSize: FontSize = FontSize.NORMAL,
+    val fontSize: FontSizeScale = FontSize.NORMAL,
     val displaySize: DisplaySize = DisplaySize.NORMAL,
     val theme: String? = null,
 ) {

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/fragmentscenario/FragmentConfigItem.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/fragmentscenario/FragmentConfigItem.kt
@@ -3,7 +3,7 @@ package sergio.sastre.uitesting.utils.fragmentscenario
 import androidx.annotation.StyleRes
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import sergio.sastre.uitesting.utils.common.DisplaySize
-import sergio.sastre.uitesting.utils.common.FontSize
+import sergio.sastre.uitesting.utils.common.FontSizeScale
 import sergio.sastre.uitesting.utils.common.Orientation
 import sergio.sastre.uitesting.utils.common.UiMode
 
@@ -11,7 +11,7 @@ data class FragmentConfigItem(
     val orientation: Orientation? = null,
     val uiMode: UiMode? = null,
     val locale: String? = null,
-    val fontSize: FontSize? = null,
+    val fontSize: FontSizeScale? = null,
     val displaySize: DisplaySize? = null,
     @StyleRes val theme: Int? = null,
 ) {
@@ -26,7 +26,7 @@ data class FragmentConfigItem(
                 val theme = themeInfo.substring(themeInfo.lastIndexOf('/') + 1)
                 nonNullProperties.add(theme.replace(".","_").uppercase())
             }
-            fontSize?.let { nonNullProperties.add("FONT_${it.name}") }
+            fontSize?.let { nonNullProperties.add("FONT_${it.valueAsName()}") }
             displaySize?.let { nonNullProperties.add("DISPLAY_${it.name}") }
             orientation?.let { nonNullProperties.add(it.name) }
             return nonNullProperties.joinToString(separator = "_")

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/fragmentscenario/FragmentScenarioConfigurator.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/fragmentscenario/FragmentScenarioConfigurator.kt
@@ -29,7 +29,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.test.core.app.ActivityScenario
 import sergio.sastre.uitesting.utils.activityscenario.ActivityScenarioConfigurator
 import sergio.sastre.uitesting.utils.common.DisplaySize
-import sergio.sastre.uitesting.utils.common.FontSize
+import sergio.sastre.uitesting.utils.common.FontSizeScale
 import sergio.sastre.uitesting.utils.common.LocaleUtil
 import sergio.sastre.uitesting.utils.common.Orientation
 import sergio.sastre.uitesting.utils.common.UiMode
@@ -174,7 +174,7 @@ class FragmentScenarioConfigurator<F : Fragment> constructor(
     }
 
     companion object {
-        private var fontSize: FontSize? = null
+        private var fontSize: FontSizeScale? = null
         private var locale: Locale? = null
         private var orientation: Orientation? = null
         private var uiMode: UiMode? = null
@@ -197,7 +197,7 @@ class FragmentScenarioConfigurator<F : Fragment> constructor(
             this.uiMode = uiMode
         }
 
-        fun setFontSize(fontSize: FontSize) = apply {
+        fun setFontSize(fontSize: FontSizeScale) = apply {
             this.fontSize = fontSize
         }
 

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/fontsize/FontScaleSetting.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/fontsize/FontScaleSetting.kt
@@ -6,19 +6,19 @@ package sergio.sastre.uitesting.utils.testrules.fontsize
 import android.content.res.Resources
 import android.os.Build
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
-import sergio.sastre.uitesting.utils.common.FontSize
+import sergio.sastre.uitesting.utils.common.FontSizeScale
 import sergio.sastre.uitesting.utils.utils.waitForExecuteShellCommand
 
-class FontScaleSetting internal constructor() {
+internal class FontScaleSetting internal constructor() {
 
     private val resources
         get() = getInstrumentation().targetContext.resources
 
-    fun get(): FontSize {
-        return FontSize.from(resources.configuration.fontScale)
+    internal fun get(): FontSizeScale {
+        return FontSizeScale.Value(resources.configuration.fontScale)
     }
 
-    fun set(scale: FontSize) {
+    internal fun set(scale: FontSizeScale) {
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 changeFontScaleFromApi24(scale)
@@ -30,19 +30,21 @@ class FontScaleSetting internal constructor() {
         }
     }
 
-    private fun changeFontScaleFromApi24(scale: FontSize) {
-        getInstrumentation().waitForExecuteShellCommand("settings put system font_scale " + scale.value)
+    private fun changeFontScaleFromApi24(fontScale: FontSizeScale) {
+        getInstrumentation().waitForExecuteShellCommand(
+            "settings put system font_scale " + fontScale.scale
+        )
     }
 
     @Suppress("DEPRECATION")
-    private fun changeFontScalePreApi24(scale: FontSize) {
-        resources.configuration.fontScale = java.lang.Float.parseFloat(scale.value)
+    private fun changeFontScalePreApi24(fontScale: FontSizeScale) {
+        resources.configuration.fontScale = fontScale.scale
         val metrics = Resources.getSystem().displayMetrics
         metrics.scaledDensity = resources.configuration.fontScale * metrics.density
         resources.updateConfiguration(resources.configuration, metrics)
     }
 
-    private fun saveFontScaleError(scale: FontSize): RuntimeException {
-        return RuntimeException("Unable to save font size " + scale.name)
+    private fun saveFontScaleError(fontScale: FontSizeScale): RuntimeException {
+        return RuntimeException("Unable to save font size scale" + fontScale.scale)
     }
 }

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/fontsize/FontSizeTestRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/fontsize/FontSizeTestRule.kt
@@ -2,10 +2,13 @@ package sergio.sastre.uitesting.utils.testrules.fontsize
 
 import android.os.SystemClock
 import android.util.Log
+import androidx.annotation.Discouraged
+
+import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
-import org.junit.rules.TestRule
 import sergio.sastre.uitesting.utils.common.FontSize
+import sergio.sastre.uitesting.utils.common.FontSizeScale
 import sergio.sastre.uitesting.utils.testrules.Condition
 import sergio.sastre.uitesting.utils.testrules.fontsize.FontSizeTestRule.FontScaleStatement.Companion.MAX_RETRIES_TO_WAIT_FOR_SETTING
 import sergio.sastre.uitesting.utils.testrules.fontsize.FontSizeTestRule.FontScaleStatement.Companion.SLEEP_TO_WAIT_FOR_SETTING_MILLIS
@@ -19,7 +22,7 @@ import sergio.sastre.uitesting.utils.testrules.fontsize.FontSizeTestRule.FontSca
  * WARNING: It's not compatible with Robolectric
  */
 class FontSizeTestRule(
-    private val fontSize: FontSize
+    private val fontSize: FontSizeScale
 ) : TestRule {
 
     companion object {
@@ -31,7 +34,20 @@ class FontSizeTestRule(
 
         fun largeFontScaleTestRule(): FontSizeTestRule = FontSizeTestRule(FontSize.LARGE)
 
+        @Discouraged("use xlargeFontScaleTestRule() instead")
         fun hugeFontScaleTestRule(): FontSizeTestRule = FontSizeTestRule(FontSize.HUGE)
+
+        fun xlargeFontScaleTestRule(): FontSizeTestRule = FontSizeTestRule(FontSize.XLARGE)
+
+        fun xxlargeFontScaleTestRule(): FontSizeTestRule = FontSizeTestRule(FontSize.XXLARGE)
+
+        fun xxxlargeFontScaleTestRule(): FontSizeTestRule = FontSizeTestRule(FontSize.XXXLARGE)
+
+        fun maximumLinearFontScaleTestRule(): FontSizeTestRule = FontSizeTestRule(FontSize.MAXIMUM_LINEAR)
+
+        fun maximumNonLinearFontScaleTestRule(): FontSizeTestRule = FontSizeTestRule(FontSize.MAXIMUM_NON_LINEAR)
+
+        fun largestFontScaleTestRule(): FontSizeTestRule = FontSizeTestRule(FontSize.LARGEST)
     }
 
     private var timeOutInMillis = MAX_RETRIES_TO_WAIT_FOR_SETTING * SLEEP_TO_WAIT_FOR_SETTING_MILLIS
@@ -46,7 +62,7 @@ class FontSizeTestRule(
         private val baseStatement: Statement,
         private val description: Description,
         private val scaleSetting: FontScaleSetting,
-        private val scale: FontSize,
+        private val scale: FontSizeScale,
         private val timeOutInMillis: Int,
     ) : Statement() {
 
@@ -61,7 +77,7 @@ class FontSizeTestRule(
             } catch (throwable: Throwable) {
                 val testName = "${description.testClass.simpleName}\$${description.methodName}"
                 val errorMessage =
-                    "Test $testName failed on setting FontSize to ${scale.name}"
+                    "Test $testName failed on setting FontSize to ${scale.scale}"
                 Log.e(TAG, errorMessage)
                 throw throwable
             } finally {
@@ -70,7 +86,7 @@ class FontSizeTestRule(
             }
         }
 
-        private fun scaleMatches(scale: FontSize): Condition {
+        private fun scaleMatches(scale: FontSizeScale): Condition {
             return object : Condition {
                 override fun holds(): Boolean {
                     return scaleSetting.get() === scale
@@ -79,7 +95,7 @@ class FontSizeTestRule(
         }
 
         @Synchronized
-        private fun sleepUntil(condition: Condition, expectedFontSize: FontSize) {
+        private fun sleepUntil(condition: Condition, expectedFontSize: FontSizeScale) {
             var iterations = 0
             var retries = 0
             while (!condition.holds()) {
@@ -90,7 +106,7 @@ class FontSizeTestRule(
                 if (mustRetry) {
                     retries++
                     scaleSetting.set(expectedFontSize)
-                    Log.d(TAG, "trying to set FontSize to ${expectedFontSize.name}, $retries retry")
+                    Log.d(TAG, "trying to set font size scale to ${expectedFontSize.scale}, $retries retry")
                 }
                 if (iterations == retriesCount) {
                     throw timeoutError()


### PR DESCRIPTION
FontSize Config supports
- Custom Values e.g. `FontSizeScale.Value(1.25f)`
- Default Non-Linear values e.g. `FontSize.XXXLARGE //1.8f`

Cross-Library updates
- Shot 6.1.0 + maxPixels
- Roborazzi 1.10.1 + ImageComparator & Metadata
- Paparazzi 1.3.3