### PR TITLE
Release/2.3.1

### DIFF
--- a/android-testify/build.gradle
+++ b/android-testify/build.gradle
@@ -62,7 +62,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "android-testify"
-            version = '2.3.0'
+            version = '2.3.1'
 
             afterEvaluate {
                 from components.release

--- a/dropshots/build.gradle
+++ b/dropshots/build.gradle
@@ -61,7 +61,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "dropshots"
-            version = '2.3.0'
+            version = '2.3.1'
 
             afterEvaluate {
                 from components.release

--- a/mapper-paparazzi/build.gradle
+++ b/mapper-paparazzi/build.gradle
@@ -49,7 +49,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "mapper-paparazzi"
-            version = '2.3.0'
+            version = '2.3.1'
 
             afterEvaluate {
                 from components.release

--- a/mapper-roborazzi/build.gradle
+++ b/mapper-roborazzi/build.gradle
@@ -50,7 +50,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "mapper-roborazzi"
-            version = '2.3.0'
+            version = '2.3.1'
 
             afterEvaluate {
                 from components.release

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -57,7 +57,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "paparazzi"
-            version = '2.3.0'
+            version = '2.3.1'
 
             afterEvaluate {
                 from components.release

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -41,7 +41,7 @@ android {
 
 dependencies {
     implementation project(':utils')
-    implementation "org.robolectric:robolectric:4.11.1"
+    implementation "org.robolectric:robolectric:4.12"
 }
 
 //https://www.talentica.com/blogs/publish-your-android-library-on-jitpack-for-better-reachability/
@@ -50,7 +50,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "robolectric"
-            version = '2.3.0'
+            version = '2.3.1'
 
             afterEvaluate {
                 from components.release

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -41,7 +41,7 @@ android {
 
 dependencies {
     implementation project(':utils')
-    implementation "org.robolectric:robolectric:4.12"
+    implementation "org.robolectric:robolectric:4.12.1"
 }
 
 //https://www.talentica.com/blogs/publish-your-android-library-on-jitpack-for-better-reachability/

--- a/roborazzi/build.gradle
+++ b/roborazzi/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation project(':robolectric')
     implementation project(':mapper-roborazzi')
 
-    api 'io.github.takahirom.roborazzi:roborazzi:1.10.1'
+    api 'io.github.takahirom.roborazzi:roborazzi:1.11.0'
     api 'androidx.test.espresso:espresso-core:3.5.1'
     api 'org.hamcrest:hamcrest:2.2'
 
@@ -64,7 +64,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "roborazzi"
-            version = '2.3.0'
+            version = '2.3.1'
 
             afterEvaluate {
                 from components.release

--- a/shot/build.gradle
+++ b/shot/build.gradle
@@ -61,7 +61,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "shot"
-            version = '2.3.0'
+            version = '2.3.1'
 
             afterEvaluate {
                 from components.release

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -73,7 +73,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "utils"
-            version = '2.3.0'
+            version = '2.3.1'
 
             afterEvaluate {
                 from components.release


### PR DESCRIPTION
Library upgrades
- Roborazzi to 1.11.0
- Robolectric to 4.12.1

> NOTE
Robolectric 4.12.1 Supports Native Graphics on Windows. Therefore, you could run Roborazzi screenshot tests on Windows as well (theoretically)!