### PR TITLE
2.3.5

### DIFF
--- a/android-testify/build.gradle
+++ b/android-testify/build.gradle
@@ -62,7 +62,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "android-testify"
-            version = '2.3.4'
+            version = '2.3.5'
 
             afterEvaluate {
                 from components.release

--- a/dropshots/build.gradle
+++ b/dropshots/build.gradle
@@ -61,7 +61,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "dropshots"
-            version = '2.3.4'
+            version = '2.3.5'
 
             afterEvaluate {
                 from components.release

--- a/mapper-paparazzi/build.gradle
+++ b/mapper-paparazzi/build.gradle
@@ -49,7 +49,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "mapper-paparazzi"
-            version = '2.3.4'
+            version = '2.3.5'
 
             afterEvaluate {
                 from components.release

--- a/mapper-roborazzi/build.gradle
+++ b/mapper-roborazzi/build.gradle
@@ -50,7 +50,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "mapper-roborazzi"
-            version = '2.3.4'
+            version = '2.3.5'
 
             afterEvaluate {
                 from components.release

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -57,7 +57,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "paparazzi"
-            version = '2.3.4'
+            version = '2.3.5'
 
             afterEvaluate {
                 from components.release

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -50,7 +50,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "robolectric"
-            version = '2.3.4'
+            version = '2.3.5'
 
             afterEvaluate {
                 from components.release

--- a/roborazzi/build.gradle
+++ b/roborazzi/build.gradle
@@ -64,7 +64,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "roborazzi"
-            version = '2.3.4'
+            version = '2.3.5'
 
             afterEvaluate {
                 from components.release

--- a/shot/build.gradle
+++ b/shot/build.gradle
@@ -61,7 +61,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "shot"
-            version = '2.3.4'
+            version = '2.3.5'
 
             afterEvaluate {
                 from components.release

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -60,10 +60,10 @@ dependencies {
     api ('androidx.core:core-ktx:1.9.0') {
         because '1.10.0 caused troubles with Paparazzi in the past'
     }
-    api 'androidx.test.ext:junit:1.2.1'
-    api 'androidx.test.espresso:espresso-core:3.6.1'
-    api 'androidx.compose.ui:ui-test-junit4:1.6.8'
-    api 'androidx.fragment:fragment-ktx:1.8.1'
+    api 'androidx.test.ext:junit:1.1.5'
+    api 'androidx.test.espresso:espresso-core:3.5.1'
+    api 'androidx.compose.ui:ui-test-junit4:1.5.4'
+    api 'androidx.fragment:fragment-ktx:1.6.2'
     implementation 'org.lsposed.hiddenapibypass:hiddenapibypass:4.3'
 }
 

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -73,7 +73,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "utils"
-            version = '2.3.4'
+            version = '2.3.5'
 
             afterEvaluate {
                 from components.release


### PR DESCRIPTION
- Downgrade some dependencies in `:utils` that only throw exceptions when running Android-Testify with GradleManagedDevices