### PR TITLE
Release/2.5.0

### DIFF
--- a/android-testify/build.gradle
+++ b/android-testify/build.gradle
@@ -65,7 +65,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "android-testify"
-            version = '2.4.0'
+            version = '2.5.0'
 
             afterEvaluate {
                 from components.release

--- a/dropshots/build.gradle
+++ b/dropshots/build.gradle
@@ -64,7 +64,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "dropshots"
-            version = '2.4.0'
+            version = '2.5.0'
 
             afterEvaluate {
                 from components.release

--- a/mapper-paparazzi/build.gradle
+++ b/mapper-paparazzi/build.gradle
@@ -49,7 +49,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "mapper-paparazzi"
-            version = '2.4.0'
+            version = '2.5.0'
 
             afterEvaluate {
                 from components.release

--- a/mapper-roborazzi/build.gradle
+++ b/mapper-roborazzi/build.gradle
@@ -50,7 +50,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "mapper-roborazzi"
-            version = '2.4.0'
+            version = '2.5.0'
 
             afterEvaluate {
                 from components.release

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -48,7 +48,7 @@ android {
 dependencies {
     implementation project(':utils')
     api project(':mapper-paparazzi')
-    api('app.cash.paparazzi:paparazzi:1.3.3')
+    api('app.cash.paparazzi:paparazzi:1.3.4')
 }
 
 //https://www.talentica.com/blogs/publish-your-android-library-on-jitpack-for-better-reachability/

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -57,7 +57,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "paparazzi"
-            version = '2.4.0'
+            version = '2.5.0'
 
             afterEvaluate {
                 from components.release

--- a/paparazzi/src/main/java/sergio/sastre/uitesting/paparazzi/config/PaparazziWrapperConfigAdapter.kt
+++ b/paparazzi/src/main/java/sergio/sastre/uitesting/paparazzi/config/PaparazziWrapperConfigAdapter.kt
@@ -40,24 +40,24 @@ internal class PaparazziWrapperConfigAdapter(
     fun asPaparazziDensity(): Density =
         when (config.density) {
             PaparazziWrapperDensity.XXXHIGH -> Density.XXXHIGH
-            PaparazziWrapperDensity.DPI_560 -> Density.DPI_560
+            PaparazziWrapperDensity.DPI_560 -> Density(560)
             PaparazziWrapperDensity.XXHIGH -> Density.XXHIGH
-            PaparazziWrapperDensity.DPI_440 -> Density.DPI_440
-            PaparazziWrapperDensity.DPI_420 -> Density.DPI_420
-            PaparazziWrapperDensity.DPI_400 -> Density.DPI_400
-            PaparazziWrapperDensity.DPI_360 -> Density.DPI_360
+            PaparazziWrapperDensity.DPI_440 -> Density(440)
+            PaparazziWrapperDensity.DPI_420 -> Density(420)
+            PaparazziWrapperDensity.DPI_400 -> Density(400)
+            PaparazziWrapperDensity.DPI_360 -> Density(360)
             PaparazziWrapperDensity.XHIGH -> Density.XHIGH
-            PaparazziWrapperDensity.DPI_260 -> Density.DPI_260
-            PaparazziWrapperDensity.DPI_280 -> Density.DPI_280
-            PaparazziWrapperDensity.DPI_300 -> Density.DPI_300
-            PaparazziWrapperDensity.DPI_340 -> Density.DPI_340
+            PaparazziWrapperDensity.DPI_260 -> Density(260)
+            PaparazziWrapperDensity.DPI_280 -> Density(280)
+            PaparazziWrapperDensity.DPI_300 -> Density(300)
+            PaparazziWrapperDensity.DPI_340 -> Density(340)
             PaparazziWrapperDensity.HIGH -> Density.HIGH
-            PaparazziWrapperDensity.DPI_220 -> Density.DPI_220
+            PaparazziWrapperDensity.DPI_220 -> Density(220)
             PaparazziWrapperDensity.TV -> Density.TV
-            PaparazziWrapperDensity.DPI_200 -> Density.DPI_200
-            PaparazziWrapperDensity.DPI_180 -> Density.DPI_180
+            PaparazziWrapperDensity.DPI_200 -> Density(200)
+            PaparazziWrapperDensity.DPI_180 -> Density(180)
             PaparazziWrapperDensity.MEDIUM -> Density.MEDIUM
-            PaparazziWrapperDensity.DPI_140 -> Density.DPI_140
+            PaparazziWrapperDensity.DPI_140 -> Density(140)
             PaparazziWrapperDensity.LOW -> Density.LOW
             PaparazziWrapperDensity.ANYDPI -> Density.ANYDPI
             PaparazziWrapperDensity.NODPI -> Density.NODPI

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -50,7 +50,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "robolectric"
-            version = '2.4.0'
+            version = '2.5.0'
 
             afterEvaluate {
                 from components.release

--- a/roborazzi/build.gradle
+++ b/roborazzi/build.gradle
@@ -64,7 +64,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "roborazzi"
-            version = '2.4.0'
+            version = '2.5.0'
 
             afterEvaluate {
                 from components.release

--- a/shot/build.gradle
+++ b/shot/build.gradle
@@ -61,7 +61,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "shot"
-            version = '2.4.0'
+            version = '2.5.0'
 
             afterEvaluate {
                 from components.release

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -71,7 +71,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "utils"
-            version = '2.4.0'
+            version = '2.5.0'
 
             afterEvaluate {
                 from components.release


### PR DESCRIPTION
**Library compatibility updates**
 ✅ Paparazzi  1.3.3 -> 1.3.4  
 
 **Info**
Paparazzi 1.3.4 made some API changes in Density, what resulted in crashes if using it for Cross-Library screenshot tests with AndroidUiTestingUtils. This version makes possible Cross-Library screenshot tests with Paparazzi 1.3.4

⚠️ Paparazzi 1.3.4 requires AGP 8.3.2+