### PR TITLE
Prepare CrossLibrary features for 2.6.0

### DIFF
--- a/android-testify/build.gradle
+++ b/android-testify/build.gradle
@@ -65,7 +65,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "android-testify"
-            version = '2.5.0'
+            version = '2.6.0'
 
             afterEvaluate {
                 from components.release

--- a/android-testify/src/main/java/sergio/sastre/uitesting/android_testify/AndroidTestifyConfig.kt
+++ b/android-testify/src/main/java/sergio/sastre/uitesting/android_testify/AndroidTestifyConfig.kt
@@ -1,14 +1,13 @@
 package sergio.sastre.uitesting.android_testify
 
 import android.graphics.Rect
-import android.view.ViewGroup
 import androidx.annotation.ColorInt
 import dev.testify.CompareMethod
 import dev.testify.core.ExclusionRectProvider
 import sergio.sastre.uitesting.utils.crosslibrary.config.BitmapCaptureMethod
 import sergio.sastre.uitesting.utils.crosslibrary.config.LibraryConfig
 
-class AndroidTestifyConfig(
+data class AndroidTestifyConfig(
     val bitmapCaptureMethod: BitmapCaptureMethod? = null,
     val exactness: Float = 0.9f,
     val enableReporter: Boolean = false,

--- a/dropshots/build.gradle
+++ b/dropshots/build.gradle
@@ -64,7 +64,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "dropshots"
-            version = '2.5.0'
+            version = '2.6.0'
 
             afterEvaluate {
                 from components.release

--- a/dropshots/src/main/java/sergio/sastre/uitesting/dropshots/DropshotsConfig.kt
+++ b/dropshots/src/main/java/sergio/sastre/uitesting/dropshots/DropshotsConfig.kt
@@ -8,7 +8,7 @@ import com.dropbox.dropshots.ResultValidator
 import sergio.sastre.uitesting.utils.crosslibrary.config.BitmapCaptureMethod
 import sergio.sastre.uitesting.utils.crosslibrary.config.LibraryConfig
 
-class DropshotsConfig(
+data class DropshotsConfig(
     val resultValidator: ResultValidator = CountValidator(0),
     val imageComparator: ImageComparator = SimpleImageComparator(maxDistance = 0.004f),
     val bitmapCaptureMethod: BitmapCaptureMethod? = null,

--- a/mapper-paparazzi/build.gradle
+++ b/mapper-paparazzi/build.gradle
@@ -49,7 +49,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "mapper-paparazzi"
-            version = '2.5.0'
+            version = '2.6.0'
 
             afterEvaluate {
                 from components.release

--- a/mapper-paparazzi/src/main/java/sergio/sastre/uitesting/mapper/paparazzi/PaparazziConfig.kt
+++ b/mapper-paparazzi/src/main/java/sergio/sastre/uitesting/mapper/paparazzi/PaparazziConfig.kt
@@ -1,5 +1,6 @@
 package sergio.sastre.uitesting.mapper.paparazzi
 
+import sergio.sastre.uitesting.mapper.paparazzi.wrapper.AccessibilityRenderExtension
 import sergio.sastre.uitesting.mapper.paparazzi.wrapper.DeviceConfig
 import sergio.sastre.uitesting.mapper.paparazzi.wrapper.Environment
 import sergio.sastre.uitesting.mapper.paparazzi.wrapper.RenderExtension
@@ -18,9 +19,9 @@ import sergio.sastre.uitesting.utils.crosslibrary.config.LibraryConfig
  *          considering the orientation (e.g. width and height switched for Landscape)
  * @param softButtons: false for all wrapped DeviceConfigs, contrary to Paparazzi's default.
  *          That's because of this default renderingMode: if softButtons ==  true, they overlap
- *          the view, and are displaded on top of it.
+ *          the view, and are displaced on top of it.
  */
-class PaparazziConfig(
+data class PaparazziConfig(
     val maxPercentageDiff: Double = 0.1,
     val deviceConfig: DeviceConfig = DeviceConfig.NEXUS_5,
     val deviceSystemUiVisibility: DeviceSystemUiVisibility = DeviceSystemUiVisibility(),
@@ -28,7 +29,19 @@ class PaparazziConfig(
     val snapshotViewOffsetMillis: Long = 0L,
     val renderingMode: RenderingMode? = null,
     val renderExtensions: Set<RenderExtension> = emptySet(),
-) : LibraryConfig
+    val useDeviceResolution: Boolean = false,
+    val validateAccessibility: Boolean = false,
+) : LibraryConfig {
+
+    fun overrideForDefaultAccessibility(): PaparazziConfig {
+        return this.copy(
+            deviceConfig = this.deviceConfig.increaseWidthForAccessibilityExtension(),
+            renderingMode = RenderingMode.NORMAL,
+            renderExtensions = setOf(AccessibilityRenderExtension()),
+            validateAccessibility = false, // Paparazzi does not support it together with RenderExtensions
+        )
+    }
+}
 
 data class DeviceSystemUiVisibility(
     val softButtons: Boolean = false,

--- a/mapper-paparazzi/src/main/java/sergio/sastre/uitesting/mapper/paparazzi/wrapper/Density.kt
+++ b/mapper-paparazzi/src/main/java/sergio/sastre/uitesting/mapper/paparazzi/wrapper/Density.kt
@@ -1,26 +1,31 @@
 package sergio.sastre.uitesting.mapper.paparazzi.wrapper
 
-enum class Density {
-    XXXHIGH,
-    DPI_560,
-    XXHIGH,
-    DPI_440,
-    DPI_420,
-    DPI_400,
-    DPI_360,
-    XHIGH,
-    DPI_260,
-    DPI_280,
-    DPI_300,
-    DPI_340,
-    HIGH,
-    DPI_220,
-    TV,
-    DPI_200,
-    DPI_180,
-    MEDIUM,
-    DPI_140,
-    LOW,
-    ANYDPI,
-    NODPI,
+interface DpiDensity {
+    val dpi: Int
+    class Value(override val dpi: Int) : DpiDensity
+}
+
+enum class Density(override val dpi: Int) : DpiDensity {
+    XXXHIGH(640),
+    DPI_560(560),
+    XXHIGH(480),
+    DPI_440(440),
+    DPI_420(420),
+    DPI_400(400),
+    DPI_360(360),
+    XHIGH(480),
+    DPI_260(260),
+    DPI_280(280),
+    DPI_300(300),
+    DPI_340(340),
+    HIGH(240),
+    DPI_220(220),
+    TV(213),
+    DPI_200(200),
+    DPI_180(180),
+    MEDIUM(160),
+    DPI_140(140),
+    LOW(120),
+    ANYDPI(0xFFFE),
+    NODPI(0xFFFF)
 }

--- a/mapper-paparazzi/src/main/java/sergio/sastre/uitesting/mapper/paparazzi/wrapper/DeviceConfig.kt
+++ b/mapper-paparazzi/src/main/java/sergio/sastre/uitesting/mapper/paparazzi/wrapper/DeviceConfig.kt
@@ -5,12 +5,21 @@ data class DeviceConfig(
     val screenWidth: Int = 768,
     val xdpi: Int = 320,
     val ydpi: Int = 320,
-    val density: Density = Density.XHIGH,
+    val density: DpiDensity = Density.XHIGH,
     val ratio: ScreenRatio = ScreenRatio.NOTLONG,
     val size: ScreenSize = ScreenSize.NORMAL,
     val navigation: Navigation = Navigation.NONAV,
     val released: String = "November 13, 2012"
 ) {
+
+    /**
+     * The accessibilityExtension takes up half the width, therefore use this to expand it
+     */
+    fun increaseWidthForAccessibilityExtension() : DeviceConfig {
+        return copy(
+            screenWidth = this.screenWidth * 2
+        )
+    }
 
     companion object {
         @JvmField

--- a/mapper-paparazzi/src/main/java/sergio/sastre/uitesting/mapper/paparazzi/wrapper/Environment.kt
+++ b/mapper-paparazzi/src/main/java/sergio/sastre/uitesting/mapper/paparazzi/wrapper/Environment.kt
@@ -3,7 +3,6 @@ package sergio.sastre.uitesting.mapper.paparazzi.wrapper
 import java.util.*
 
 data class Environment(
-    val platformDir: String? = null,
     val compileSdkVersion: Int? = null,
     val appTestDir: String? = null,
     val packageName: String? = null,

--- a/mapper-roborazzi/build.gradle
+++ b/mapper-roborazzi/build.gradle
@@ -50,7 +50,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "mapper-roborazzi"
-            version = '2.5.0'
+            version = '2.6.0'
 
             afterEvaluate {
                 from components.release

--- a/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/RoborazziConfig.kt
+++ b/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/RoborazziConfig.kt
@@ -1,6 +1,8 @@
 package sergio.sastre.uitesting.mapper.roborazzi
 
 import androidx.annotation.ColorInt
+import sergio.sastre.uitesting.mapper.roborazzi.wrapper.CaptureType
+import sergio.sastre.uitesting.mapper.roborazzi.wrapper.DumpExplanation.AccessibilityExplanation
 import sergio.sastre.uitesting.mapper.roborazzi.wrapper.RoborazziOptions
 import sergio.sastre.uitesting.mapper.roborazzi.wrapper.screen.DeviceScreen
 import sergio.sastre.uitesting.utils.crosslibrary.config.BitmapCaptureMethod
@@ -13,6 +15,14 @@ data class RoborazziConfig(
     @ColorInt val backgroundColor: Int? = null,
     val bitmapCaptureMethod: BitmapCaptureMethod? = null,
 ) : LibraryConfig {
+
+    fun overrideForDefaultAccessibility(): RoborazziConfig {
+        return copy(
+            roborazziOptions = roborazziOptions.copy(
+                captureType = CaptureType.Dump(AccessibilityExplanation)
+            ),
+        )
+    }
 
     companion object {
         const val DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH = "build/outputs/roborazzi"

--- a/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/AiAssertion.kt
+++ b/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/AiAssertion.kt
@@ -1,0 +1,8 @@
+package sergio.sastre.uitesting.mapper.roborazzi.wrapper
+
+data class AiAssertion(
+    val assertionPrompt: String,
+    val requiredFulfillmentPercent: Int,
+    val failIfNotFulfilled: Boolean = true
+)
+

--- a/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/CaptureType.kt
+++ b/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/CaptureType.kt
@@ -3,7 +3,7 @@ package sergio.sastre.uitesting.mapper.roborazzi.wrapper
 import sergio.sastre.uitesting.mapper.roborazzi.wrapper.DumpExplanation.DefaultExplanation
 
 sealed interface CaptureType {
-    object Screenshot : CaptureType
+    data object Screenshot : CaptureType
     data class Dump(val explanation: DumpExplanation = DefaultExplanation) : CaptureType
 }
 

--- a/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/ImageIoFormat.kt
+++ b/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/ImageIoFormat.kt
@@ -1,0 +1,6 @@
+package sergio.sastre.uitesting.mapper.roborazzi.wrapper
+
+enum class ImageIoFormat {
+    LosslessWebPImageIoFormat,
+    ImageIoFormat
+}

--- a/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/RecordOptions.kt
+++ b/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/RecordOptions.kt
@@ -3,5 +3,6 @@ package sergio.sastre.uitesting.mapper.roborazzi.wrapper
 data class RecordOptions(
     val resizeScale: Double =
         checkNotNull(System.getProperty("roborazzi.record.resizeScale", "1.0")).toDouble(),
-    val applyDeviceCrop: Boolean = false
+    val applyDeviceCrop: Boolean = false,
+    val imageIoFormat: ImageIoFormat = ImageIoFormat.ImageIoFormat,
 )

--- a/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/RoborazziOptions.kt
+++ b/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/RoborazziOptions.kt
@@ -1,8 +1,15 @@
 package sergio.sastre.uitesting.mapper.roborazzi.wrapper
 
+/**
+ * WARNING:
+ * @param aiAssertions requires you to add the corresponding Roborazzi module, namely one of these:
+ * 1. roborazzi-ai-gemini -> testImplementation(io.github.takahirom.roborazzi:roborazzi-ai-gemini)
+ * 2. roborazzi-ai-openai -> testImplementation(io.github.takahirom.roborazzi:roborazzi-ai-openai)
+ */
 data class RoborazziOptions(
     val captureType: CaptureType = CaptureType.Screenshot,
     val compareOptions: CompareOptions = CompareOptions(),
     val recordOptions: RecordOptions = RecordOptions(),
     val contextData: Map<String, Any> = emptyMap(),
+    val aiAssertions: List<AiAssertion> = emptyList()
 )

--- a/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/screen/DeviceScreen.kt
+++ b/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/screen/DeviceScreen.kt
@@ -5,7 +5,7 @@ data class DeviceScreen(
     val heightDp: Int,
     val size: ScreenSize = ScreenSize.NORMAL,
     val aspect: ScreenAspect = ScreenAspect.NOTLONG,
-    val density: ScreenDensity = ScreenDensity.MDPI,
+    val density: DpiDensity = ScreenDensity.MDPI,
     val defaultOrientation: ScreenOrientation = ScreenOrientation.PORTRAIT,
     val round: RoundScreen? = null,
     val type: ScreenType? = null,

--- a/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/screen/ScreenDensity.kt
+++ b/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/screen/ScreenDensity.kt
@@ -1,26 +1,31 @@
 package sergio.sastre.uitesting.mapper.roborazzi.wrapper.screen
 
-enum class ScreenDensity(val qualifier: String) {
-    XXXHDPI("xxxhdpi"),
-    DPI_560("560dpi"),
-    XXHDPI("xxhdpi"),
-    DPI_440("440dpi"),
-    DPI_420("420dpi"),
-    DPI_400("400dpi"),
-    DPI_360("360dpi"),
-    XHDPI("xhdpi"),
-    DPI_260("260dpi"),
-    DPI_280("280dpi"),
-    DPI_300("300dpi"),
-    DPI_340("340dpi"),
-    HDPI("hdpi"),
-    DPI_220("220dpi"),
-    TVDPI("tvdpi"),
-    DPI_200("200dpi"),
-    DPI_180("180dpi"),
-    MDPI("mdpi"),
-    DPI_140("140dpi"),
-    LDPI("ldpi"),
-    ANYDPI("anydpi"),
-    NODPI("nodpi"),
+interface DpiDensity {
+    val dpi: Int
+    class Value(override val dpi: Int) : DpiDensity
+}
+
+enum class ScreenDensity(val qualifier: String, override val dpi: Int): DpiDensity {
+    XXXHDPI("xxxhdpi", 640),
+    DPI_560("560dpi", 560),
+    XXHDPI("xxhdpi", 480),
+    DPI_440("440dpi", 440),
+    DPI_420("420dpi", 420),
+    DPI_400("400dpi", 400),
+    DPI_360("360dpi", 360),
+    XHDPI("xhdpi", 480),
+    DPI_260("260dpi", 260),
+    DPI_280("280dpi", 280),
+    DPI_300("300dpi", 300),
+    DPI_340("340dpi", 340),
+    HDPI("hdpi", 240),
+    DPI_220("220dpi", 220),
+    TVDPI("tvdpi", 213),
+    DPI_200("200dpi", 200),
+    DPI_180("180dpi", 180),
+    MDPI("mdpi", 160),
+    DPI_140("140dpi", 140),
+    LDPI("ldpi", 120),
+    ANYDPI("anydpi", 0xFFFE),
+    NODPI("nodpi", 0xFFFF),
 }

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -48,7 +48,7 @@ android {
 dependencies {
     implementation project(':utils')
     api project(':mapper-paparazzi')
-    api('app.cash.paparazzi:paparazzi:1.3.4')
+    api('app.cash.paparazzi:paparazzi:1.3.5')
 }
 
 //https://www.talentica.com/blogs/publish-your-android-library-on-jitpack-for-better-reachability/
@@ -57,7 +57,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "paparazzi"
-            version = '2.5.0'
+            version = '2.6.0'
 
             afterEvaluate {
                 from components.release

--- a/paparazzi/src/main/java/sergio/sastre/uitesting/paparazzi/config/PaparazziForComposableTestRuleBuilder.kt
+++ b/paparazzi/src/main/java/sergio/sastre/uitesting/paparazzi/config/PaparazziForComposableTestRuleBuilder.kt
@@ -36,6 +36,8 @@ class PaparazziForComposableTestRuleBuilder {
             maxPercentDifference = paparazziConfig.maxPercentageDiff,
             environment = sharedTestAdapter.asEnvironment(),
             renderExtensions = sharedTestAdapter.asRenderExtensions(),
+            useDeviceResolution = paparazziConfig.useDeviceResolution,
+            validateAccessibility = paparazziConfig.validateAccessibility,
         )
     }
 }

--- a/paparazzi/src/main/java/sergio/sastre/uitesting/paparazzi/config/PaparazziWrapperConfigAdapter.kt
+++ b/paparazzi/src/main/java/sergio/sastre/uitesting/paparazzi/config/PaparazziWrapperConfigAdapter.kt
@@ -61,6 +61,7 @@ internal class PaparazziWrapperConfigAdapter(
             PaparazziWrapperDensity.LOW -> Density.LOW
             PaparazziWrapperDensity.ANYDPI -> Density.ANYDPI
             PaparazziWrapperDensity.NODPI -> Density.NODPI
+            else -> Density(config.density.dpi)
         }
 
     fun asPaparazziScreenRatio(): ScreenRatio =
@@ -99,7 +100,6 @@ internal class PaparazziWrapperConfigAdapter(
         val environment = detectEnvironment()
         val configEnvironment = paparazziConfig.environment
         return environment.copy(
-            platformDir = configEnvironment?.platformDir ?: environment.platformDir,
             compileSdkVersion = configEnvironment?.compileSdkVersion
                 ?: environment.compileSdkVersion,
             appTestDir = configEnvironment?.appTestDir ?: environment.appTestDir,

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -41,7 +41,7 @@ android {
 
 dependencies {
     implementation project(':utils')
-    implementation "org.robolectric:robolectric:4.13"
+    implementation "org.robolectric:robolectric:4.14"
 }
 
 //https://www.talentica.com/blogs/publish-your-android-library-on-jitpack-for-better-reachability/
@@ -50,7 +50,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "robolectric"
-            version = '2.5.0'
+            version = '2.6.0'
 
             afterEvaluate {
                 from components.release

--- a/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/config/RobolectricQualifiersBuilder.kt
+++ b/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/config/RobolectricQualifiersBuilder.kt
@@ -20,7 +20,7 @@ object RobolectricQualifiersBuilder {
                 round?.let { listOfQualifiers.add(it.qualifier) }
                 orientationQualifier(configOrientation).let { listOfQualifiers.add(it) }
                 type?.let { listOfQualifiers.add(it.qualifier) }
-                density.let { listOfQualifiers.add(it.qualifier) }
+                density.let { listOfQualifiers.add(it.valueAsQualifier()) }
 
                 setQualifiers(listOfQualifiers.joinToString(separator = "-"))
             }

--- a/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/config/screen/DeviceScreen.kt
+++ b/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/config/screen/DeviceScreen.kt
@@ -9,7 +9,7 @@ data class DeviceScreen(
     val heightDp: Int,
     val size: ScreenSize = ScreenSize.NORMAL,
     val aspect: ScreenAspect = ScreenAspect.NOTLONG,
-    val density: ScreenDensity = ScreenDensity.MDPI,
+    val density: DpiDensity = ScreenDensity.MDPI,
     val defaultOrientation: ScreenOrientation = ScreenOrientation.PORTRAIT,
     val round: RoundScreen? = null,
     val type: ScreenType? = null,

--- a/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/config/screen/ScreenDensity.kt
+++ b/robolectric/src/main/java/sergio/sastre/uitesting/robolectric/config/screen/ScreenDensity.kt
@@ -1,26 +1,37 @@
 package sergio.sastre.uitesting.robolectric.config.screen
 
-enum class ScreenDensity(val qualifier: String) {
-    XXXHDPI("xxxhdpi"),
-    DPI_560("560dpi"),
-    XXHDPI("xxhdpi"),
-    DPI_440("440dpi"),
-    DPI_420("420dpi"),
-    DPI_400("400dpi"),
-    DPI_360("360dpi"),
-    XHDPI("xhdpi"),
-    DPI_260("260dpi"),
-    DPI_280("280dpi"),
-    DPI_300("300dpi"),
-    DPI_340("340dpi"),
-    HDPI("hdpi"),
-    DPI_220("220dpi"),
-    TVDPI("tvdpi"),
-    DPI_200("200dpi"),
-    DPI_180("180dpi"),
-    MDPI("mdpi"),
-    DPI_140("140dpi"),
-    LDPI("ldpi"),
-    ANYDPI("anydpi"),
-    NODPI("nodpi"),
+interface DpiDensity {
+    val dpi: Int
+    class Value(override val dpi: Int) : DpiDensity
+
+    fun valueAsQualifier(): String =
+        when (this is ScreenDensity) {
+            true -> this.qualifier
+            false -> this.dpi.toString() + "dpi"
+        }
+}
+
+enum class ScreenDensity(val qualifier: String, override val dpi: Int): DpiDensity {
+    XXXHDPI("xxxhdpi", 640),
+    DPI_560("560dpi", 560),
+    XXHDPI("xxhdpi", 480),
+    DPI_440("440dpi", 440),
+    DPI_420("420dpi", 420),
+    DPI_400("400dpi", 400),
+    DPI_360("360dpi", 360),
+    XHDPI("xhdpi", 480),
+    DPI_260("260dpi", 260),
+    DPI_280("280dpi", 280),
+    DPI_300("300dpi", 300),
+    DPI_340("340dpi", 340),
+    HDPI("hdpi", 240),
+    DPI_220("220dpi", 220),
+    TVDPI("tvdpi", 213),
+    DPI_200("200dpi", 200),
+    DPI_180("180dpi", 180),
+    MDPI("mdpi", 160),
+    DPI_140("140dpi", 140),
+    LDPI("ldpi", 120),
+    ANYDPI("anydpi", 0xFFFE),
+    NODPI("nodpi", 0xFFFF),
 }

--- a/roborazzi/build.gradle
+++ b/roborazzi/build.gradle
@@ -51,11 +51,12 @@ dependencies {
     implementation project(':robolectric')
     implementation project(':mapper-roborazzi')
 
-    api 'io.github.takahirom.roborazzi:roborazzi:1.26.0'
-    api 'androidx.test.espresso:espresso-core:3.5.1'
-    api 'org.hamcrest:hamcrest:2.2'
+    implementation("org.hamcrest:hamcrest:2.2")
+    implementation("io.github.darkxanter:webp-imageio:0.3.3")
+    implementation("androidx.activity:activity-compose:1.9.2")
 
-    api 'androidx.activity:activity-compose:1.9.2'
+    api 'io.github.takahirom.roborazzi:roborazzi:1.32.2'
+    api 'androidx.test.espresso:espresso-core:3.5.1'
 }
 
 //https://www.talentica.com/blogs/publish-your-android-library-on-jitpack-for-better-reachability/
@@ -64,7 +65,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "roborazzi"
-            version = '2.5.0'
+            version = '2.6.0'
 
             afterEvaluate {
                 from components.release

--- a/shot/build.gradle
+++ b/shot/build.gradle
@@ -61,7 +61,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "shot"
-            version = '2.5.0'
+            version = '2.6.0'
 
             afterEvaluate {
                 from components.release

--- a/shot/src/main/java/sergio/sastre/uitesting/shot/ShotConfig.kt
+++ b/shot/src/main/java/sergio/sastre/uitesting/shot/ShotConfig.kt
@@ -10,7 +10,7 @@ import sergio.sastre.uitesting.utils.crosslibrary.config.LibraryConfig
  *    1. Requires bitmapCaptureMethod = null
  *    2. Works only with Views, not with Composables
  */
-class ShotConfig(
+data class ShotConfig(
     val ignoredViews: List<Int> = emptyList(),
     val prepareUIForScreenshot: () -> Unit = {},
     val bitmapCaptureMethod: BitmapCaptureMethod? = null,

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -71,7 +71,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "utils"
-            version = '2.5.0'
+            version = '2.6.0'
 
             afterEvaluate {
                 from components.release


### PR DESCRIPTION
Paparazzi & Roborazzi
- overrideForDefaultAccessibility() to easy enable Accessibility
- support custom Density when defining Device

Paparazzi:
- Support 2.3.5
- Support useDeviceResolution & validateAccessibility

Roborazzi:
- Support 1.32.2
- Support record WebP & aiAssertions