### PR TITLE
Update libraries and release version

### DIFF
--- a/android-testify/build.gradle
+++ b/android-testify/build.gradle
@@ -50,8 +50,8 @@ android {
 
 dependencies {
     implementation project(':utils')
-    implementation 'androidx.test:rules:1.6.1'
-    api 'dev.testify:testify:3.2.2'
+    implementation 'androidx.test:rules:1.7.0'
+    api 'dev.testify:testify:3.2.3'
     api ("androidx.activity:activity-compose:1.9.3") {
         because "the last one requires compose option 1.6.x"
     }
@@ -63,7 +63,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "android-testify"
-            version = '2.7.0'
+            version = '2.8.0'
 
             afterEvaluate {
                 from components.release

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,8 +36,8 @@ android {
 dependencies {
     implementation project(':utils')
 
-    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'com.google.android.material:material:1.13.0'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 }

--- a/dropshots/build.gradle
+++ b/dropshots/build.gradle
@@ -49,8 +49,8 @@ android {
 
 dependencies {
     implementation project(':utils')
-    implementation 'androidx.test:rules:1.6.1'
-    api 'com.dropbox.dropshots:dropshots:0.5.0'
+    implementation 'androidx.test:rules:1.7.0'
+    api 'com.dropbox.dropshots:dropshots:0.5.1'
     api ("androidx.activity:activity-compose:1.9.3") {
         because "the last one requires compose option 1.6.x"
     }
@@ -62,7 +62,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "dropshots"
-            version = '2.7.0'
+            version = '2.8.0'
 
             afterEvaluate {
                 from components.release

--- a/mapper-paparazzi/build.gradle
+++ b/mapper-paparazzi/build.gradle
@@ -48,7 +48,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "mapper-paparazzi"
-            version = '2.7.0'
+            version = '2.8.0'
 
             afterEvaluate {
                 from components.release

--- a/mapper-roborazzi/build.gradle
+++ b/mapper-roborazzi/build.gradle
@@ -49,7 +49,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "mapper-roborazzi"
-            version = '2.7.0'
+            version = '2.8.0'
 
             afterEvaluate {
                 from components.release

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -56,7 +56,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "paparazzi"
-            version = '2.7.0'
+            version = '2.8.0'
 
             afterEvaluate {
                 from components.release

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -40,7 +40,7 @@ android {
 
 dependencies {
     implementation project(':utils')
-    implementation "org.robolectric:robolectric:4.14.1"
+    implementation "org.robolectric:robolectric:4.16"
 }
 
 //https://www.talentica.com/blogs/publish-your-android-library-on-jitpack-for-better-reachability/
@@ -49,7 +49,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "robolectric"
-            version = '2.7.0'
+            version = '2.8.0'
 
             afterEvaluate {
                 from components.release

--- a/roborazzi/build.gradle
+++ b/roborazzi/build.gradle
@@ -56,8 +56,8 @@ dependencies {
         because "the last one requires compose option 1.6.x"
     }
 
-    api 'io.github.takahirom.roborazzi:roborazzi:1.44.0'
-    api 'androidx.test.espresso:espresso-core:3.6.1'
+    api 'io.github.takahirom.roborazzi:roborazzi:1.51.0'
+    api 'androidx.test.espresso:espresso-core:3.7.0'
 }
 
 //https://www.talentica.com/blogs/publish-your-android-library-on-jitpack-for-better-reachability/
@@ -66,7 +66,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "roborazzi"
-            version = '2.7.0'
+            version = '2.8.0'
 
             afterEvaluate {
                 from components.release

--- a/shot/build.gradle
+++ b/shot/build.gradle
@@ -62,7 +62,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "shot"
-            version = '2.7.0'
+            version = '2.8.0'
 
             afterEvaluate {
                 from components.release

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -52,14 +52,12 @@ android {
 
 dependencies {
     api 'androidx.appcompat:appcompat:1.7.1'
-    api 'com.google.android.material:material:1.12.0'
-    api 'androidx.test:core:1.6.1'
-
-    api 'androidx.test.espresso:espresso-core:3.6.1'
-
-    api 'androidx.compose.ui:ui-test-junit4:1.8.2'
-    api 'androidx.fragment:fragment-ktx:1.8.8'
-    implementation 'androidx.core:core-ktx:1.16.0'
+    api 'com.google.android.material:material:1.13.0'
+    api 'androidx.test.espresso:espresso-core:3.7.0'
+    api 'androidx.compose.ui:ui-test-junit4:1.9.4'
+    api 'androidx.fragment:fragment-ktx:1.8.9'
+    implementation 'androidx.test:core:1.7.0'
+    implementation 'androidx.core:core-ktx:1.17.0'
     implementation 'org.lsposed.hiddenapibypass:hiddenapibypass:6.1'
 }
 
@@ -69,7 +67,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.sergio-sastre'
             artifactId = "utils"
-            version = '2.7.0'
+            version = '2.8.0'
 
             afterEvaluate {
                 from components.release


### PR DESCRIPTION
- Roborazzi 1.44 -> 1.51.0
- Testify 3.2.2 -> 3.2.3
- Dropshots 0.5.0 -> 0.5.1
- Robolectric 4.14.1 -> 4.16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated library dependencies to latest versions for improved compatibility and stability.
  * Bumped release version from 2.7.0 to 2.8.0 across all modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->