### PR TITLE
update dropshots to 0.6.0

### DIFF
--- a/dropshots/build.gradle
+++ b/dropshots/build.gradle
@@ -50,7 +50,7 @@ android {
 dependencies {
     implementation project(':utils')
     implementation 'androidx.test:rules:1.7.0'
-    api 'com.dropbox.dropshots:dropshots:0.5.1'
+    api 'com.dropbox.dropshots:dropshots:0.6.0'
     api ("androidx.activity:activity-compose:1.9.3") {
         because "the last one requires compose option 1.6.x"
     }

--- a/dropshots/src/main/java/sergio/sastre/uitesting/dropshots/DropshotsConfig.kt
+++ b/dropshots/src/main/java/sergio/sastre/uitesting/dropshots/DropshotsConfig.kt
@@ -1,12 +1,15 @@
 package sergio.sastre.uitesting.dropshots
 
+import android.os.Environment
 import androidx.annotation.ColorInt
+import androidx.test.platform.app.InstrumentationRegistry
 import com.dropbox.differ.ImageComparator
 import com.dropbox.differ.SimpleImageComparator
 import com.dropbox.dropshots.CountValidator
 import com.dropbox.dropshots.ResultValidator
 import sergio.sastre.uitesting.utils.crosslibrary.config.BitmapCaptureMethod
 import sergio.sastre.uitesting.utils.crosslibrary.config.LibraryConfig
+import java.io.File
 
 data class DropshotsConfig(
     val resultValidator: ResultValidator = CountValidator(0),
@@ -14,4 +17,12 @@ data class DropshotsConfig(
     val bitmapCaptureMethod: BitmapCaptureMethod? = null,
     @get:ColorInt val backgroundColor: Int? = null,
     val filePath: String? = null,
+    val rootScreenshotDir: File = defaultRootScreenshotDirectory()
 ) : LibraryConfig
+
+private fun defaultRootScreenshotDirectory(): File {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val externalStorageDir = Environment
+        .getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+    return File(externalStorageDir, "screenshots/${context.packageName}")
+}

--- a/dropshots/src/main/java/sergio/sastre/uitesting/dropshots/DropshotsScreenshotTestRuleForComposable.kt
+++ b/dropshots/src/main/java/sergio/sastre/uitesting/dropshots/DropshotsScreenshotTestRuleForComposable.kt
@@ -1,7 +1,6 @@
 package sergio.sastre.uitesting.dropshots
 
 import androidx.compose.runtime.Composable
-import com.dropbox.dropshots.Dropshots
 import org.junit.rules.RuleChain
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
@@ -22,12 +21,7 @@ class DropshotsScreenshotTestRuleForComposable(
     }
 
     private val dropshotsRule: ScreenshotTaker by lazy {
-        ScreenshotTaker(
-            Dropshots(
-                resultValidator = dropshotsConfig.resultValidator,
-                imageComparator = dropshotsConfig.imageComparator,
-            )
-        )
+        createScreenshotTaker(dropshotsConfig)
     }
 
     private var dropshotsConfig: DropshotsConfig = DropshotsConfig()

--- a/dropshots/src/main/java/sergio/sastre/uitesting/dropshots/DropshotsScreenshotTestRuleForView.kt
+++ b/dropshots/src/main/java/sergio/sastre/uitesting/dropshots/DropshotsScreenshotTestRuleForView.kt
@@ -4,7 +4,6 @@ import android.app.Dialog
 import android.content.Context
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
-import com.dropbox.dropshots.Dropshots
 import org.junit.rules.RuleChain
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
@@ -28,12 +27,7 @@ class DropshotsScreenshotTestRuleForView(
     }
 
     private val dropshotsRule: ScreenshotTaker by lazy {
-        ScreenshotTaker(
-            Dropshots(
-                resultValidator = dropshotsConfig.resultValidator,
-                imageComparator = dropshotsConfig.imageComparator,
-            )
-        )
+        createScreenshotTaker(dropshotsConfig)
     }
 
     private var dropshotsConfig: DropshotsConfig = DropshotsConfig()

--- a/dropshots/src/main/java/sergio/sastre/uitesting/dropshots/ScreenshotTaker.kt
+++ b/dropshots/src/main/java/sergio/sastre/uitesting/dropshots/ScreenshotTaker.kt
@@ -34,12 +34,14 @@ internal class ScreenshotTaker(
                     name = name,
                     filePath = filePath,
                 )
+
             is BitmapCaptureMethod.PixelCopy ->
                 assertSnapshot(
                     bitmap = view.drawToBitmapWithElevation(config = bitmapCaptureMethod.config),
                     name = name,
                     filePath = filePath,
                 )
+
             null -> assertSnapshot(
                 view = view,
                 name = name,
@@ -61,12 +63,14 @@ internal class ScreenshotTaker(
                     name = name,
                     filePath = filePath,
                 )
+
             is BitmapCaptureMethod.PixelCopy ->
                 assertSnapshot(
                     bitmap = dialog.drawToBitmapWithElevation(config = bitmapCaptureMethod.config),
                     name = name,
                     filePath = filePath,
                 )
+
             null -> assertSnapshot(
                 view = dialog.window!!.decorView,
                 name = name,
@@ -104,4 +108,13 @@ internal class ScreenshotTaker(
             )
         }
     }
+}
+
+internal fun createScreenshotTaker(dropshotsConfig: DropshotsConfig): ScreenshotTaker {
+    val dropshots = Dropshots(
+        resultValidator = dropshotsConfig.resultValidator,
+        imageComparator = dropshotsConfig.imageComparator,
+        rootScreenshotDirectory = dropshotsConfig.rootScreenshotDir
+    )
+    return ScreenshotTaker(dropshots)
 }


### PR DESCRIPTION
Expand api to add option to set root directory in cross-library screenshot tests that use Dropshots

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable screenshot directory path, defaulting to the device's Downloads folder.

* **Chores**
  * Updated underlying screenshot library dependency to version 0.6.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sergio-sastre/AndroidUiTestingUtils/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->