### PR TITLE
Feature/update high text contrast test rule

### DIFF
--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/accessibility/HighTextContrastTestRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/accessibility/HighTextContrastTestRule.kt
@@ -14,7 +14,10 @@ import java.io.IOException
  */
 @Deprecated(
     message = "Use the OutlineTextTestRule instead. This will be removed in version 2.10.0",
-    replaceWith = ReplaceWith("OutlineTextTestRule(OutlineText)"))
+    replaceWith = ReplaceWith(
+        "OutlineTextTestRule()",
+        imports = ["sergio.sastre.uitesting.utils.testrules.accessibility.outlinetext.OutlineTextTestRule"]
+    ))
 class HighTextContrastTestRule: TestRule {
     override fun apply(base: Statement, description: Description): Statement {
         return object : Statement() {

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/accessibility/HighTextContrastTestRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/accessibility/HighTextContrastTestRule.kt
@@ -12,6 +12,9 @@ import java.io.IOException
  *
  * WARNING: Only works on Instrumentation tests, not on Robolectric tests.
  */
+@Deprecated(
+    message = "Use the OutlineTextTestRule instead. This will be removed in version 2.10.0",
+    replaceWith = ReplaceWith("OutlineTextTestRule(OutlineText)"))
 class HighTextContrastTestRule: TestRule {
     override fun apply(base: Statement, description: Description): Statement {
         return object : Statement() {

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/accessibility/outlinetext/OutlineText.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/accessibility/outlinetext/OutlineText.kt
@@ -1,0 +1,6 @@
+package sergio.sastre.uitesting.utils.testrules.accessibility.outlinetext
+
+enum class OutlineText(val value: Int) {
+    ENABLED(1),
+    DISABLED(0)
+}

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/accessibility/outlinetext/OutlineTextTestRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/accessibility/outlinetext/OutlineTextTestRule.kt
@@ -1,0 +1,45 @@
+package sergio.sastre.uitesting.utils.testrules.accessibility.outlinetext
+
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import sergio.sastre.uitesting.utils.testrules.accessibility.outlinetext.OutlineText.ENABLED
+import sergio.sastre.uitesting.utils.utils.waitForExecuteShellCommand
+import java.io.IOException
+
+/**
+ * Allows to enable/disable high text contrast accessibility during a test.
+ *
+ * WARNING: Only works on Instrumentation tests, not on Robolectric tests.
+ */
+class OutlineTextTestRule(val outlineText: OutlineText = ENABLED) : TestRule {
+
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            @Throws(Throwable::class)
+            override fun evaluate() {
+                val preTestOutlineText = getCurrentOutlineText()
+                try {
+                    setOutlineText(outlineText)
+                    base.evaluate()
+                } finally {
+                    setOutlineText(preTestOutlineText)
+                }
+            }
+        }
+    }
+
+    private fun getCurrentOutlineText(): OutlineText {
+        val outlineText =
+            getInstrumentation().waitForExecuteShellCommand("settings get secure high_text_contrast_enabled")
+        val outlineTextValue = outlineText.substringAfterLast("=").toInt()
+        return OutlineText.entries.find { it.value == outlineTextValue } ?: OutlineText.DISABLED
+    }
+
+
+    @Throws(IOException::class)
+    private fun setOutlineText(enabled: OutlineText) {
+        getInstrumentation().waitForExecuteShellCommand("settings put secure high_text_contrast_enabled ${enabled.value}")
+    }
+}

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/accessibility/outlinetext/OutlineTextTestRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/accessibility/outlinetext/OutlineTextTestRule.kt
@@ -33,10 +33,9 @@ class OutlineTextTestRule(val outlineText: OutlineText = ENABLED) : TestRule {
     private fun getCurrentOutlineText(): OutlineText {
         val outlineText =
             getInstrumentation().waitForExecuteShellCommand("settings get secure high_text_contrast_enabled")
-        val outlineTextValue = outlineText.substringAfterLast("=").toInt()
+        val outlineTextValue = outlineText.substringAfterLast("=").toIntOrNull()
         return OutlineText.entries.find { it.value == outlineTextValue } ?: OutlineText.DISABLED
     }
-
 
     @Throws(IOException::class)
     private fun setOutlineText(enabled: OutlineText) {

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/utils/Extensions.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/utils/Extensions.kt
@@ -7,6 +7,7 @@ import android.app.Dialog
 import android.app.Instrumentation
 import android.content.pm.PackageManager
 import android.os.ParcelFileDescriptor
+import android.os.ParcelFileDescriptor.AutoCloseInputStream
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -24,11 +25,10 @@ import sergio.sastre.uitesting.utils.common.Orientation
 import java.io.BufferedReader
 import java.io.InputStreamReader
 
-private fun waitForCompletion(descriptor: ParcelFileDescriptor) {
-    BufferedReader(InputStreamReader(ParcelFileDescriptor.AutoCloseInputStream(descriptor))).use {
-        it.readText()
-    }
-}
+private fun waitForCompletion(descriptor: ParcelFileDescriptor): String =
+    BufferedReader(InputStreamReader(AutoCloseInputStream(descriptor)))
+        .use { it.readText() }
+        .trim()
 
 /**
  * Returns a view with [layoutId] using the context of [Activity], and attaches it to the root.
@@ -118,9 +118,8 @@ fun Activity.rotateTo(orientation: Orientation) {
     }
 }
 
-fun Instrumentation.waitForExecuteShellCommand(command: String) {
+fun Instrumentation.waitForExecuteShellCommand(command: String): String =
     waitForCompletion(uiAutomation.executeShellCommand(command))
-}
 
 /**
  * Waits for the Ui thread to be Idle and calculates the expected dimensions of the


### PR DESCRIPTION
Deprecate HighTextContrastTestRule in favour of OutlineTextContrastTestRule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `OutlineTextTestRule` for controlling text contrast accessibility settings during tests. The rule automatically manages and restores text contrast state before and after each test.

* **Chores**
  * `HighTextContrastTestRule` has been deprecated with planned removal in version 2.10.0. Migrate to the replacement `OutlineTextTestRule`, for which IDE quick-fixes provide automated migration suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->