### PR TITLE
Add NavigationModeTestRule

### DIFF
--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     implementation 'androidx.test:core:1.7.0'
     implementation 'androidx.core:core-ktx:1.18.0'
     implementation 'org.lsposed.hiddenapibypass:hiddenapibypass:6.1'
+    implementation 'androidx.test.uiautomator:uiautomator:2.4.0'
 }
 
 //https://www.talentica.com/blogs/publish-your-android-library-on-jitpack-for-better-reachability/

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/navigation/Navigation.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/navigation/Navigation.kt
@@ -1,0 +1,6 @@
+package sergio.sastre.uitesting.utils.testrules.systemui.navigation
+
+enum class Navigation(val adbValue: String, val navModeValue: Int) {
+    GESTURAL("com.android.internal.systemui.navbar.gestural", 2),
+    THREE_BUTTON("com.android.internal.systemui.navbar.threebutton", 0)
+}

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/navigation/NavigationModeTestRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/navigation/NavigationModeTestRule.kt
@@ -1,0 +1,107 @@
+package sergio.sastre.uitesting.utils.testrules.systemui.navigation
+
+import android.app.Instrumentation
+import android.util.Log
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import sergio.sastre.uitesting.utils.utils.waitForExecuteShellCommand
+
+class NavigationModeTestRule(
+    private val navigation: Navigation
+) : TestRule {
+
+    companion object {
+        const val TIMEOUT_IN_MS = 10_000L
+    }
+
+    private val TAG = javaClass.simpleName
+
+    override fun apply(base: Statement, description: Description): Statement = object : Statement() {
+        override fun evaluate() {
+            val instrumentation = getInstrumentation()
+            val targetMode = NavigationMode.from(navigation)
+            val originalMode = instrumentation.getNavigationMode()
+
+            try {
+                instrumentation.setNavigationMode(targetMode)
+                instrumentation.waitUntilUiMatches(navigation, TIMEOUT_IN_MS)
+                base.evaluate()
+            } finally {
+                instrumentation.setNavigationMode(originalMode)
+                UiDevice.getInstance(instrumentation).waitForIdle()
+                instrumentation.waitForIdleSync()
+            }
+        }
+    }
+
+    private fun Instrumentation.getNavigationMode(): NavigationMode {
+        val currentNavigationMode =
+            waitForExecuteShellCommand("settings get secure navigation_mode").toIntOrNull()
+        return NavigationMode.entries.find { it.navModeValue == currentNavigationMode }
+            ?: NavigationMode.GESTURAL
+    }
+
+    private fun Instrumentation.setNavigationMode(targetMode: NavigationMode) {
+        if (getNavigationMode() == targetMode) return
+
+        NavigationMode.entries.filter { it != targetMode }.forEach {
+            waitForExecuteShellCommand("cmd overlay disable ${it.adbValue}")
+        }
+        waitForExecuteShellCommand("cmd overlay enable ${targetMode.adbValue}")
+
+        // Wait for system setting to change
+        val startTime = System.currentTimeMillis()
+        while (getNavigationMode() != targetMode && System.currentTimeMillis() - startTime < TIMEOUT_IN_MS) {
+            Thread.sleep(100)
+        }
+
+        if (getNavigationMode() != targetMode) {
+            Log.e(TAG, "Timed out waiting for system setting to change to: $targetMode")
+        }
+    }
+
+    private fun Instrumentation.waitUntilUiMatches(navigation: Navigation, timeout: Long) {
+        val device = UiDevice.getInstance(this)
+        val startTime = System.currentTimeMillis()
+
+        val home = By.res("com.android.systemui", "home")
+        val back = By.res("com.android.systemui", "back")
+        val recents = By.res("com.android.systemui", "recent_apps")
+
+        while (System.currentTimeMillis() - startTime < timeout) {
+            val isHomeVisible = device.hasObject(home)
+            val isBackVisible = device.hasObject(back)
+            val isRecentsVisible = device.hasObject(recents)
+
+            val isMatching = when (navigation) {
+                Navigation.THREE_BUTTON -> isHomeVisible && isBackVisible && isRecentsVisible
+                Navigation.GESTURAL -> !isHomeVisible && !isBackVisible && !isRecentsVisible
+            }
+
+            if (isMatching) {
+                device.waitForIdle()
+                waitForIdleSync()
+                return
+            }
+            Thread.sleep(100)
+        }
+        Log.e(TAG, "Timed out waiting for Navigation UI to reflect mode: $navigation")
+    }
+
+    private enum class NavigationMode(val adbValue: String, val navModeValue: Int) {
+        THREE_BUTTON(Navigation.THREE_BUTTON.adbValue, Navigation.THREE_BUTTON.navModeValue),
+        GESTURAL(Navigation.GESTURAL.adbValue, Navigation.GESTURAL.navModeValue),
+        TWO_BUTTON("com.android.internal.systemui.navbar.twobutton", 1);
+
+        companion object {
+            fun from(navigation: Navigation) = when (navigation) {
+                Navigation.THREE_BUTTON -> THREE_BUTTON
+                Navigation.GESTURAL -> GESTURAL
+            }
+        }
+    }
+}

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/navigation/NavigationModeTestRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/navigation/NavigationModeTestRule.kt
@@ -10,6 +10,19 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import sergio.sastre.uitesting.utils.utils.waitForExecuteShellCommand
 
+/**
+ * A [TestRule] that changes the system navigation mode (e.g., Three-button or Gestural)
+ * for the duration of a test and restores it afterwards.
+ *
+ * This rule uses shell commands (`cmd overlay`) to toggle the system navigation bar overlays
+ * and uses UI Automator to wait until the UI components (home, back, recents) correctly
+ * reflect the requested mode.
+ *
+ * **Note:** This rule is not compatible with Robolectric as it relies on system-level
+ * shell commands and UI Automator, which require a real device or emulator.
+ *
+ * @param navigation The target [Navigation] mode to set during the test.
+ */
 class NavigationModeTestRule(
     private val navigation: Navigation
 ) : TestRule {
@@ -30,6 +43,12 @@ class NavigationModeTestRule(
                 instrumentation.setNavigationMode(targetMode)
                 instrumentation.waitUntilUiMatches(navigation, TIMEOUT_IN_MS)
                 base.evaluate()
+            } catch (throwable: Throwable) {
+                val testName = "${description.testClass.simpleName}\$${description.methodName}"
+                val errorMessage =
+                    "Test $testName failed on setting NavigationMode to ${navigation.name}"
+                Log.e(TAG, errorMessage)
+                throw throwable
             } finally {
                 instrumentation.setNavigationMode(originalMode)
                 UiDevice.getInstance(instrumentation).waitForIdle()
@@ -38,6 +57,9 @@ class NavigationModeTestRule(
         }
     }
 
+    /**
+     * Reads the current navigation mode from system settings.
+     */
     private fun Instrumentation.getNavigationMode(): NavigationMode {
         val currentNavigationMode =
             waitForExecuteShellCommand("settings get secure navigation_mode").toIntOrNull()
@@ -45,6 +67,9 @@ class NavigationModeTestRule(
             ?: NavigationMode.GESTURAL
     }
 
+    /**
+     * Sets the navigation mode using shell commands (`cmd overlay`) and waits for the system setting to change.
+     */
     private fun Instrumentation.setNavigationMode(targetMode: NavigationMode) {
         if (getNavigationMode() == targetMode) return
 
@@ -60,10 +85,14 @@ class NavigationModeTestRule(
         }
 
         if (getNavigationMode() != targetMode) {
-            Log.e(TAG, "Timed out waiting for system setting to change to: $targetMode")
+            throw IllegalStateException("Timed out waiting for system setting to change to: $targetMode")
         }
     }
 
+    /**
+     * Waits until the System UI reflects the requested navigation mode.
+     * It checks for the presence or absence of the home, back, and recents buttons.
+     */
     private fun Instrumentation.waitUntilUiMatches(navigation: Navigation, timeout: Long) {
         val device = UiDevice.getInstance(this)
         val startTime = System.currentTimeMillis()
@@ -89,7 +118,7 @@ class NavigationModeTestRule(
             }
             Thread.sleep(100)
         }
-        Log.e(TAG, "Timed out waiting for Navigation UI to reflect mode: $navigation")
+        throw IllegalStateException("Timed out waiting for Navigation UI to reflect mode: $navigation")
     }
 
     private enum class NavigationMode(val adbValue: String, val navModeValue: Int) {

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/navigation/NavigationModeTestRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/navigation/NavigationModeTestRule.kt
@@ -14,12 +14,7 @@ import sergio.sastre.uitesting.utils.utils.waitForExecuteShellCommand
  * A [TestRule] that changes the system navigation mode (e.g., Three-button or Gestural)
  * for the duration of a test and restores it afterwards.
  *
- * This rule uses shell commands (`cmd overlay`) to toggle the system navigation bar overlays
- * and uses UI Automator to wait until the UI components (home, back, recents) correctly
- * reflect the requested mode.
- *
- * **Note:** This rule is not compatible with Robolectric as it relies on system-level
- * shell commands and UI Automator, which require a real device or emulator.
+ * WARNING: Only works on Instrumentation tests, not on Robolectric tests.
  *
  * @param navigation The target [Navigation] mode to set during the test.
  */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for testing Android apps with gestural and three-button system navigation.
  * Navigation mode is now applied automatically before a test and restored afterward.
  * Added validation to wait until the expected navigation button layout is shown before the test runs.
* **Chores / Testing**
  * Updated the test utilities to include UI Automator support for navigation-layout verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->