### PR TITLE
Support full screen screenshot and favour them in a SystemUiTestRule

### DIFF
--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/SystemUiTestRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/SystemUiTestRule.kt
@@ -1,0 +1,36 @@
+package sergio.sastre.uitesting.utils.testrules.systemui
+
+import android.graphics.Bitmap
+import org.junit.rules.RuleChain
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import sergio.sastre.uitesting.utils.testrules.systemui.navigation.Navigation
+import sergio.sastre.uitesting.utils.testrules.systemui.navigation.NavigationModeTestRule
+import sergio.sastre.uitesting.utils.testrules.systemui.statusbar.ClockTime
+import sergio.sastre.uitesting.utils.testrules.systemui.statusbar.StatusBarTestRule
+import sergio.sastre.uitesting.utils.utils.drawFullScreenToBitmap as fullScreenToBitmap
+
+/**
+ * A [TestRule] that combines [StatusBarTestRule] and [NavigationModeTestRule]
+ * to provide a consistent System UI for testing.
+ *
+ * @param navigation The target [Navigation] mode.
+ * @param clockTime The time to display in the status bar.
+ */
+class SystemUiTestRule(
+    private val navigation: Navigation = Navigation.GESTURAL,
+    private val clockTime: ClockTime = ClockTime(12, 30),
+) : TestRule {
+
+    override fun apply(base: Statement, description: Description): Statement =
+        RuleChain.outerRule(StatusBarTestRule(clockTime))
+            .around(NavigationModeTestRule(navigation))
+            .apply(base, description)
+
+    /**
+     * Captures a screenshot of the entire screen.
+     * Safe to use for screenshot testing as this rule ensures the System UI state is reproducible.
+     */
+    fun drawFullScreenToBitmap(): Bitmap = fullScreenToBitmap()
+}

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/utils/DrawFullScreenToBitmap.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/utils/DrawFullScreenToBitmap.kt
@@ -12,4 +12,7 @@ import androidx.test.uiautomator.UiDevice
  * 2. You ensure they are reproducible (e.g., by using [sergio.sastre.uitesting.utils.testrules.systemui.SystemUiTestRule]).
  */
 fun drawFullScreenToBitmap(): Bitmap =
-    UiDevice.getInstance(getInstrumentation()).apply { waitForIdle() }.takeScreenshot()!!
+    UiDevice.getInstance(getInstrumentation())
+        .apply { waitForIdle() }
+        .takeScreenshot()
+        ?: error("Unable to capture a full-screen screenshot")

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/utils/DrawFullScreenToBitmap.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/utils/DrawFullScreenToBitmap.kt
@@ -1,0 +1,15 @@
+package sergio.sastre.uitesting.utils.utils
+
+import android.graphics.Bitmap
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import androidx.test.uiautomator.UiDevice
+
+/**
+ * Captures a screenshot of the entire screen, including the Status Bar and Navigation Bar.
+ *
+ * WARNING: For screenshot testing, it is NOT recommended to use this unless:
+ * 1. You exclude the status bar and navigation bar from the comparison.
+ * 2. You ensure they are reproducible (e.g., by using [sergio.sastre.uitesting.utils.testrules.systemui.SystemUiTestRule]).
+ */
+fun drawFullScreenToBitmap(): Bitmap =
+    UiDevice.getInstance(getInstrumentation()).apply { waitForIdle() }.takeScreenshot()!!


### PR DESCRIPTION
The SystemUiTestRule helps optimize for full screenshot tests with stable and reproducible statusbar and navigation bar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a testing utility to configure status bar time and navigation mode consistently.
  * Added full-screen screenshot capture, including status and navigation bars, after the interface becomes idle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->