### PR TITLE
CrossLibrary: Support Roborazzi 1.69.0 uiTreeDumpOptions 

### DIFF
--- a/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/RoborazziOptions.kt
+++ b/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/RoborazziOptions.kt
@@ -11,5 +11,6 @@ data class RoborazziOptions(
     val compareOptions: CompareOptions = CompareOptions(),
     val recordOptions: RecordOptions = RecordOptions(),
     val contextData: Map<String, Any> = emptyMap(),
-    val aiAssertions: List<AiAssertion> = emptyList()
+    val aiAssertions: List<AiAssertion> = emptyList(),
+    val uiTreeDumpOptions: UiTreeDumpOptions? = null,
 )

--- a/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/UiTreeDumpOptions.kt
+++ b/mapper-roborazzi/src/main/java/sergio/sastre/uitesting/mapper/roborazzi/wrapper/UiTreeDumpOptions.kt
@@ -1,0 +1,5 @@
+package sergio.sastre.uitesting.mapper.roborazzi.wrapper
+
+data class UiTreeDumpOptions(
+    val annotateImage: Boolean = true
+)

--- a/roborazzi/build.gradle
+++ b/roborazzi/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation("io.github.darkxanter:webp-imageio:0.3.3")
     implementation "androidx.activity:activity-compose:1.13.0"
 
-    api 'io.github.takahirom.roborazzi:roborazzi:1.60.0'
+    api 'io.github.takahirom.roborazzi:roborazzi:1.70.0'
     api 'androidx.test.espresso:espresso-core:3.7.0'
 }
 

--- a/roborazzi/src/main/java/sergio/sastre/uitesting/roborazzi/config/RoborazziSharedTestAdapter.kt
+++ b/roborazzi/src/main/java/sergio/sastre/uitesting/roborazzi/config/RoborazziSharedTestAdapter.kt
@@ -11,6 +11,7 @@ import com.github.takahirom.roborazzi.JvmImageIoFormat
 import com.github.takahirom.roborazzi.LosslessWebPImageIoFormat
 import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.ThresholdValidator
+import com.github.takahirom.roborazzi.UiTreeDumpOptions
 import sergio.sastre.uitesting.robolectric.config.screen.DeviceScreen
 import sergio.sastre.uitesting.robolectric.config.screen.RoundScreen
 import sergio.sastre.uitesting.robolectric.config.screen.ScreenAspect
@@ -89,11 +90,16 @@ internal class RoborazziSharedTestAdapter(
                     }
                 )
 
+            val adaptedUiTreeDumpOptions = it.uiTreeDumpOptions?.let { option ->
+                UiTreeDumpOptions(annotateImage = option.annotateImage)
+            }
+
             return RoborazziOptions(
                 captureType = adaptedCaptureType,
                 compareOptions = adaptedCompareOptions,
                 contextData = it.contextData,
                 recordOptions = adaptedRecordOptions,
+                uiTreeDumpOptions = adaptedUiTreeDumpOptions,
             ).addedAiAssertions(it.aiAssertions)
         }
     }


### PR DESCRIPTION
Basic usage (isAnnotable not supported yet)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional UI tree dump configuration to Roborazzi settings.
  - Added support for enabling or disabling image annotations in UI tree dumps, enabled by default.
  - Configuration is now applied consistently when running Roborazzi tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->