### PR TITLE
Enable to hide wifi icon

### DIFF
--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/StatusBarConfig.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/StatusBarConfig.kt
@@ -4,4 +4,5 @@ import sergio.sastre.uitesting.utils.testrules.systemui.statusbar.ClockTime
 
 data class StatusBarConfig(
     val clockTime: ClockTime = ClockTime(12, 30),
+    val showWifiIcon: Boolean = true,
 )

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/SystemUiTestRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/SystemUiTestRule.kt
@@ -22,8 +22,8 @@ import sergio.sastre.uitesting.utils.utils.drawFullScreenToBitmap as fullScreenT
  * @param statusBarConfig Configuration for the system status bar.
  */
 class SystemUiTestRule(
-    private val navigationConfig: NavigationConfig = NavigationConfig(),
     private val statusBarConfig: StatusBarConfig = StatusBarConfig(),
+    private val navigationConfig: NavigationConfig = NavigationConfig(),
 ) : TestRule {
 
     override fun apply(base: Statement, description: Description): Statement =

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/SystemUiTestRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/SystemUiTestRule.kt
@@ -29,13 +29,14 @@ class SystemUiTestRule(
     override fun apply(base: Statement, description: Description): Statement =
         RuleChain.outerRule(
             StatusBarTestRule(
-                clockTime = statusBarConfig.clockTime
+                clockTime = statusBarConfig.clockTime,
+                showWifiIcon = statusBarConfig.showWifiIcon,
             )
         )
             .around(
                 NavigationModeTestRule(
                     navigation = navigationConfig.mode,
-                    customThreeButtonIdentifiers = navigationConfig.customThreeButtonIdentifiers
+                    customThreeButtonIdentifiers = navigationConfig.customThreeButtonIdentifiers,
                 )
             )
             .apply(base, description)

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/statusbar/StatusBarTestRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/statusbar/StatusBarTestRule.kt
@@ -101,7 +101,7 @@ class StatusBarTestRule(
                     val testName = "${description.testClass.simpleName}\$${description.methodName}"
                     val errorMessage =
                         "Test $testName failed on setting StatusBar in Demo Mode"
-                    Log.e(TAG, errorMessage)
+                    Log.e(TAG, errorMessage, throwable)
                     throw throwable
                 } finally {
                     monitor.removeLifecycleCallback(lifecycleCallback)

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/statusbar/StatusBarTestRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/statusbar/StatusBarTestRule.kt
@@ -36,6 +36,7 @@ class StatusBarTestRule(
     /**
      * Set a custom clock time using a string in "hh:mm" format (e.g., "12:30").
      */
+    @JvmOverloads
     constructor(
         hhmmClock: String,
         showWifiIcon: Boolean = true

--- a/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/statusbar/StatusBarTestRule.kt
+++ b/utils/src/main/java/sergio/sastre/uitesting/utils/testrules/systemui/statusbar/StatusBarTestRule.kt
@@ -1,5 +1,6 @@
 package sergio.sastre.uitesting.utils.testrules.systemui.statusbar
 
+import android.util.Log
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.UiDevice
 import org.junit.rules.TestRule
@@ -14,7 +15,7 @@ import sergio.sastre.uitesting.utils.utils.waitForExecuteShellCommand
  * It sets:
  * - Clock time: configurable (default 12:30)
  * - Battery: 100%, not plugged in
- * - Network: Wifi with full signal
+ * - Network: Either Wifi with full signal or hides the Wifi icon
  * - Notifications: Hidden
  *
  * The Demo Mode is applied when the test starts and reapplied every time an Activity
@@ -29,12 +30,16 @@ import sergio.sastre.uitesting.utils.utils.waitForExecuteShellCommand
  */
 class StatusBarTestRule(
     private val clockTime: ClockTime = ClockTime(12, 30),
+    private val showWifiIcon: Boolean = true,
 ) : TestRule {
 
     /**
      * Set a custom clock time using a string in "hh:mm" format (e.g., "12:30").
      */
-    constructor(hhmmClock: String) : this(ClockTime.from(hhmmClock))
+    constructor(
+        hhmmClock: String,
+        showWifiIcon: Boolean = true
+    ) : this(ClockTime.from(hhmmClock), showWifiIcon)
 
     private val TAG = javaClass.simpleName
 
@@ -51,6 +56,12 @@ class StatusBarTestRule(
             }
         }
 
+    private val wifiAdbCommand
+        get() = when (showWifiIcon) {
+            true -> "$BROADCAST_DEMO_COMMAND network -e wifi show -e level 4"
+            false -> "$BROADCAST_DEMO_COMMAND network -e wifi hide"
+        }
+
     private fun applyDemoMode() {
         val instrumentation = getInstrumentation()
         try {
@@ -58,14 +69,17 @@ class StatusBarTestRule(
             instrumentation.waitForExecuteShellCommand("$BROADCAST_DEMO_COMMAND enter")
             instrumentation.waitForExecuteShellCommand("$BROADCAST_DEMO_COMMAND clock -e hhmm ${clockTime.toHhmmString()}")
             instrumentation.waitForExecuteShellCommand("$BROADCAST_DEMO_COMMAND battery -e level 100 -e plugged false")
-            instrumentation.waitForExecuteShellCommand("$BROADCAST_DEMO_COMMAND network -e wifi show -e level 4")
+            instrumentation.waitForExecuteShellCommand(wifiAdbCommand)
             instrumentation.waitForExecuteShellCommand("$BROADCAST_DEMO_COMMAND notifications -e visible false")
 
             // Allow SystemUI a moment to reflect the changes
             UiDevice.getInstance(instrumentation).waitForIdle()
             instrumentation.waitForIdleSync()
         } catch (e: Exception) {
-            throw IllegalStateException("Failed to change the status bar by applying demo mode on RESUMED", e)
+            throw IllegalStateException(
+                "Failed to change the status bar by applying demo mode on RESUMED",
+                e
+            )
         }
     }
 
@@ -82,6 +96,12 @@ class StatusBarTestRule(
                     applyDemoMode()
 
                     base.evaluate()
+                } catch (throwable: Throwable) {
+                    val testName = "${description.testClass.simpleName}\$${description.methodName}"
+                    val errorMessage =
+                        "Test $testName failed on setting StatusBar in Demo Mode"
+                    Log.e(TAG, errorMessage)
+                    throw throwable
                 } finally {
                     monitor.removeLifecycleCallback(lifecycleCallback)
                     // Cleanup


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to show or hide the Wi‑Fi icon during status bar testing.
  - The Wi‑Fi icon remains visible by default, preserving existing behavior.
  - Status bar test configuration now consistently applies the selected Wi‑Fi visibility setting.

- **Bug Fixes**
  - Improved setup failure diagnostics by recording the affected test name before reporting the error.

- **Documentation**
  - Updated status bar testing documentation to describe the Wi‑Fi visibility option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->